### PR TITLE
Proofread SaysHi's Final Ch 3 Translation Update

### DIFF
--- a/English translation/ch3.txt
+++ b/English translation/ch3.txt
@@ -105,8 +105,8 @@ Aiee, uah...❤
 Ufufu, it feels so good doesn't it?
 However...*
 We are only illusions.
-Although we cannot touch you at all, you thrusted 
-into my mouth, and your waist shook in pleasue.
+Although we cannot touch you at all, you thrust 
+into my mouth, and your waist shook in pleasure.
 You feel it right?
 How pathetic...❤ What a fool-❤*
 But, there's no stopping now-❤
@@ -131,7 +131,7 @@ Oaah...❤
 初等部生徒：上
 Gonna cum? Hehe-❤
 You're so weak...❤*
-It must be so embarassing to be
+It must be so embarrassing to be
 edged by a kid's fellatio-❤*
 It's so embarrassing, 
 I'm ashamed someone like you even exists-❤*
@@ -904,10 +904,10 @@ Enduring after all that...!
 高等部生徒：上
 Ho-ra, your strength is already fading-❤**
 Fufu.
-To see you pant beneath my feet- Pathetic.
-What a lowly creature,
-squirming on the floor,
-so absentminded as my feet bestow pleasure onto you...
+To see you pant beneath my feet- Pathetic.*
+What a lowly creature, squirming on the floor,
+so absentminded as my feet bestow pleasure 
+onto you...
 
 高等部生徒：上
 Oh my, what an amazing voice-❤
@@ -1076,7 +1076,8 @@ Is your reasoning already wearing thin?*
 That's what happens when you accept 
 a succubus' temptation-❤*
 You think "I can quit at anytime",
-but there's no way you'll experience this again...❤
+but there's no way you'll experience this 
+again...❤
 Hora, hora.
 Can I keep stroking?
 Is that okay? Are you gonna cum? Should I stop?
@@ -1344,7 +1345,7 @@ Mmm, aaah-❤
 
 初等部生徒：上
 Aah, I love you mister-❤
-Thank for fufilling my last request...
+Thank for fulfilling my last request...
 I love you so much-❤
 Ooh- I'm gonna cum already.
 You're at your limit too right?-❤
@@ -1414,7 +1415,7 @@ Hora!
 It feels good when I massage you like this, right?
 The kneading of my breasts.
 A special service for your penis.
-As my breasts wrap aroud your penis,
+As my breasts wrap around your penis,
 you want me to continue kneading it, don't you?
 Fufu, I can feel your body twitching in pleasure.
 Hora, time to increase the 
@@ -1478,8 +1479,9 @@ You like it? My boobs are soft, aren't they?
 
 初等部生徒：上
 Fufu, they're still slippery from earlier,
-so it'll feel even better than before-❤
-Everyone loses once they put their penises in here-❤
+so it'll feel even better than before-❤*
+Everyone loses once they put their penises 
+in here-❤*
 Even just a little shake of my breasts,
 hora... Is enough to turn your mind into mush-❤
 
@@ -1515,7 +1517,7 @@ Your last moments were the best... Teeheehee...❤
 <AT20>
 モルジア：上
 \vo[m16]Injuring me to such an extent,
-I severely underestimated your abilites...*
+I severely underestimated your abilities...*
 \vo[m17]But, you're at the limit of your endurance, 
 aren't you?
 Hora, stare...❤
@@ -1643,8 +1645,8 @@ Was entering into my robe the correct choice?
 my breasts-❤
 Aaah-❤ I'll never get tired of this feeling-❤
 \vo[m48]Poor baby. You were so strong, 
-but you gave in the moment I swayed my sexy breasts 
-in front of your eyes-❤ Teeheehee-♪
+but you gave in the moment I swayed my sexy 
+breasts in front of your eyes-❤ Teeheehee-♪
 \vo[m49]Hora, you would do anything for these tits, 
 wouldn't you? Enjoy them as much as you like-❤
 
@@ -2362,14 +2364,14 @@ thrown in jail and kept as livestock.
 初等部生徒：上
 Teehee- Sorry to have kept you waiting!
 It's time for today's semen squeezing.*
-I wonder how I'll squeeze you today.
-Stroking you with my hands? Or maybe between my feet?*
+I wonder how I'll squeeze you today. Stroking you 
+with my hands? Or maybe between my feet?*
 Oh...?
 Fufu, or should I try just using my breasts-
-They're very popular after all-❤*
+They're very popular after all-❤
 All my slaves absolutely love being squeezed
-between these breasts. They're so big, not even your 
-hands can hold then can they?
+between these breasts. They're so big, not even 
+your hands can hold then can they? 
 Burying your face, caressing your penis...
 Teehee- You imagined it didn't you?
 Your eyes are full of expectation-❤
@@ -2379,7 +2381,7 @@ Want to see? I'll unbutton my shirt like this...
 
 初等部生徒：上
 Mm, see this gap in the middle?`
-You can peek into my lewd boobie clevage here.
+You can peek into my lewd boobie cleavage here.
 So, what do you want to do now?
 For example,
 If you thrust your penis in here and go slap slap
@@ -2422,14 +2424,14 @@ Ah, aaaaah!-❤
 Thi, this is amazing...!-❤
 
 初等部生徒：上
-Senpai, even though you're more of an adult than me,
-your face is completely melting, as my boobies 
-jerk you off-❤
-Does it really feel that good when my boobies rub your 
-penis?*
+Senpai, even though you're more of an adult than 
+me, your face is completely melting, as my 
+boobies jerk you off-❤ 
+Does it really feel that good when my boobies rub 
+your penis?*
 I bet in your mind it's heaven,
-all wrapped up in my tight loli boobies-❤
-Once once tastes my lovey-dovey- making paizuri 
+all wrapped up in my tight loli boobies-❤*
+Once one tastes my lovey-dovey- making paizuri 
 sex...❤ I can even turn senpai into a bad,
 boobie loving adult-❤ Eei, eei!-
 
@@ -2520,8 +2522,8 @@ boy will melt away within five minutes-❤
 Then when I said 
 「I will stop if you don't tell me」,
 everyone quickly gave in and told me-❤
-Ufufu. And since they were all so obedient and cute,
-I rewarded them a lot.*
+Ufufu. And since they were all so obedient and 
+cute, I rewarded them a lot.*
 I rubbed my breasts against their faces and
 gave them paizuri until they died 
 from climaxing so much.
@@ -3036,7 +3038,7 @@ I'm melting-❤❤
 
 モルジア：上
 \vo[m92]Ahnnn-❤ Your ejaculation isn't stopping at all.
-You're already climaxing continously-❤
+You're already climaxing continuously-❤
 
 レイ：上
 Hahiii......❤❤❤❤❤❤❤
@@ -3269,7 +3271,7 @@ I'm melting-❤❤
 
 モルジア：上
 \vo[m111]Ahnnn-❤ Your ejaculation isn't stopping at all.
-You're already climaxing continously-❤❤
+You're already climaxing continuously-❤❤
 
 レイ：上
 Hahiii...❤❤❤❤❤❤❤
@@ -3341,7 +3343,7 @@ The enemies have us severely outnumbered.
 We must quickly escape to someplace safe.
 
 モルジア：上
-Fufu... Preperations are finally complete-**
+Fufu... Preparations are finally complete-**
 You must lock yourselves in a room now,
 come to me...♪
 
@@ -3384,10 +3386,10 @@ Ooh...❤
 モルジア：上
 \vo[m120]Ara ara, cumming already?
 You're not going to cum pitifully from
-geting aroused on your own, are you?
+getting aroused on your own, are you?
 \vo[m121]This is an important battle for your country 
-isn't it? Is it really okay? Losing to some boobies,
-Teehee...❤
+isn't it? Is it really okay? 
+Losing to some boobies, teehee...❤
 
 モルジア：上
 \vo[m122]Oh dear-❤
@@ -3417,7 +3419,7 @@ Aah...❤ Boobieess...❤
 You didn't get aroused from seeing your ally 
 masturbate to my boobies, did you?
 \vo[m125]They call you heroes but, fufu,
-you're actally quite pathetic- Slowly losing 
+you're actually quite pathetic- Slowly losing 
 control, masturbating to my breasts-❤
 \vo[m126]Hora, while I sway my boobies for you to see,
 it's okay if you need to sit down and stroke-
@@ -3431,7 +3433,7 @@ Oghhh...❤ Aaaah-❤
 it feels soo good doesn't it?-❤
 Teehee... Just like some kind of monkey...
 \vo[m128]Hora, lose to my boobies, while staring
-into my clevage... 
+into my cleavage... 
 cum, cum right now-❤ Greenhorn-❤
 
 モルジア：上
@@ -3461,10 +3463,10 @@ Aah...❤ Boobieess...❤
 \vo[m129]Ufufu- Oh? Now you're stroking too? I guess you
 couldn't resist staring at my boobies-❤*
 \vo[m130]Oh dear, these troops really are worthless-
-All of themm are submitting to my succubus boobie breasts-❤
-They're just a group of greenhorns...
+All of them are submitting to my succubus boobie 
+breasts-❤ They're just a group of greenhorns...
 \vo[m131]Hora, stare,
-If I sway them infront of your eyes like this...❤
+If I sway them in front of your eyes like this...❤
 
 
 アクティブ：上
@@ -3498,7 +3500,7 @@ Aah-❤
 中等部生徒：上
 Haha-❤
 Couldn't you endure my breasts?*
-to be taking your penis our infront of your enemy,
+To be taking your penis out before your enemy,
 and going stroke stroke, stroke stroke,
 looks like it feels really good-❤ (giggle)
 
@@ -3512,11 +3514,11 @@ Hora... Stare at them as much as you like okay?
 Ara ara, you're stroking even faster-
 That's it, stroke stroke, stroke stroke...
 And just like that, you're in my boobie trance-
-Hora, dye my clevage in your white semen
+Hora, dye my cleavage in your white semen
 as I sway my breasts in front of your eyes-❤
 
 中等部生徒：上
-Fufu, you made my clevage all sticky-
+Fufu, you made my cleavage all sticky-
 And so much energy too, thank you-❤
 Tee-hee...
 
@@ -3536,7 +3538,7 @@ Aah-❤
 中等部生徒：上
 Haha-❤
 Couldn't you endure my breasts?*
-to be taking your penis our infront of your enemy,
+To be taking your penis out before your enemy,
 and going stroke stroke, stroke stroke,
 looks like it feels really good-❤ (giggle)
 
@@ -3550,11 +3552,11 @@ Hora... Stare at them as much as you like okay?
 Ara ara, you're stroking even faster-
 That's it, stroke stroke, stroke stroke...
 And just like that, you're in my boobie trance-
-Hora, dye my clevage in your white semen
+Hora, dye my cleavage in your white semen
 as I sway my breasts in front of your eyes-❤
 
 中等部生徒：上
-Fufu, you made my clevage all sticky-
+Fufu, you made my cleavage all sticky-
 And so much energy too, thank you-❤
 Tee-hee...
 
@@ -3574,7 +3576,7 @@ Aah-❤
 高等部生徒：上
 Ufufu, you've completely surrendered to my charms-**
 Just by being next to me, you've become 
-iressistably horny, and can't think of anything 
+irresistibly horny, and can't think of anything 
 except feeling good with me...
 Fufu. Don't worry- That's normal.
 Men are just mindless monkeys before my
@@ -3587,7 +3589,7 @@ monkey?-❤ How pathetic- Teehee...
 Ara ara, did you cum while I was laughing at you?
 Fufu, I've never seen someone so pathetic.*
 Even during the last moments of death,
-you colapsed in pure content- (giggle)
+you collapsed in pure content- (giggle)
 
 <TK7>
 レイ：上
@@ -3605,10 +3607,10 @@ Aah-❤
 高等部生徒：上
 Ufufu, you've completely surrendered to my charms-**
 Just by being next to me, you've become 
-iressistably horny, and can't think of anything 
+irresistibly horny, and can't think of anything 
 except feeling good with me...
 Fufu. Don't worry- That's normal.
-Men are just mindless monkeys before my
+Men are just mindless monkeys before my 
 beauty.
 Hm...? 
 Did you get excited when I called you a
@@ -3618,7 +3620,7 @@ monkey?-❤ How pathetic- Teehee...
 Ara ara, did you cum while I was laughing at you?
 Fufu, I've never seen someone so pathetic.*
 Even during the last moments of death,
-you colapsed in pure content- (giggle)
+you collapsed in pure content- (giggle)
 
 <TK3>
 レイ：上
@@ -3638,14 +3640,13 @@ Ahahaha.
 You started stroking on your own!-❤*
 To be unable to resist the 
 temptations of such a young girl,
-That's so adorable...❤
+that's so adorable...❤
 Hey- Can I show you how to stroke properly?
 Uh-huh, that's it, stroke the tip real hard
 like this- Aah-
 Well? Did my demonstration get you aroused?
-Teehee...
-I guess it feels even better when a girl shows
-you how to masturabte, right?
+Teehee...I guess it feels even better when 
+a girl shows you how to masturbate, right?
 
 アクティブ：上
 Ugh... No more, I'm already...❤
@@ -3653,7 +3654,7 @@ Uaaah...❤
 
 初等部生徒：上
 Ahaha. What a pathetic voice.
-Now just sit stil okay? I'll stroke you
+Now just sit still okay? I'll stroke you
 lots, so just sit back and enjoy-
 Hmm? Gonna cum? Are you going to cum?
 Can't take it anymore? I see, well in that case,
@@ -3683,22 +3684,21 @@ Oh, what's this-
 Senpai's stroking his penis too?*
 To be unable to resist the 
 temptations of such a young girl,
-That's so adorable...❤
+that's so adorable...❤
 Hey- Can I show you how to stroke properly?
 Uh-huh, that's it, stroke the tip real hard
 like this- Aah-
 Well? Did my demonstration get you aroused?
-Teehee...
-I guess it feels even better when a girl shows
-you how to masturabte, right?
+Teehee...I guess it feels even better when 
+a girl shows you how to masturbate, right?
 
 アクティブ：上
 Aah-❤ Aah-❤
 
 初等部生徒：上
-You moans are already getting louder.
+Your moans are already getting louder.
 That's too quick-❤*
-Just like the other senpai,
+Just like with the other senpai,
 I'll breathe hot air on your penis-❤
 Pshew...❤
 
@@ -3725,14 +3725,13 @@ Ahahaha.
 You started stroking on your own!-❤*
 To be unable to resist the 
 temptations of such a young girl,
-That's so adorable...❤
+that's so adorable...❤
 Hey- Can I show you how to stroke properly?
 Uh-huh, that's it, stroke the tip real hard
 like this- Aah-
 Well? Did my demonstration get you aroused?
-Teehee...
-I guess it feels even better when a girl shows
-you how to masturabte, right?
+Teehee...I guess it feels even better when 
+a girl shows you how to masturbate, right?
 
 アクティブ：上
 Ugh... No more... I'm already-❤
@@ -3740,7 +3739,7 @@ Aaah-❤
 
 初等部生徒：上
 Ahaha. What a pathetic voice.
-Now just sit stil okay? I'll stroke you
+Now just sit still okay? I'll stroke you
 lots, so just sit back and enjoy-
 Hmm? Gonna cum? Are you going to cum?
 Can't take it anymore? I see, well in that case,
@@ -3770,22 +3769,21 @@ Oh, what's this-
 Senpai's stroking his penis too?*
 To be unable to resist the 
 temptations of such a young girl,
-That's so adorable...❤
+that's so adorable...❤
 Hey- Can I show you how to stroke properly?
 Uh-huh, that's it, stroke the tip real hard
 like this- Aah-
 Well? Did my demonstration get you aroused?
-Teehee...
-I guess it feels even better when a girl shows
-you how to masturabte, right?
+Teehee...I guess it feels even better when 
+a girl shows you how to masturbate, right?
 
 アクティブ：上
 Aah-❤ Aah-❤
 
 初等部生徒：上
-You moans are already getting louder.
+Your moans are already getting louder.
 That's too quick-❤*
-Just like the other senpai,
+Just like with the other senpai,
 I'll breathe hot air on your penis-❤
 Pshew...❤
 
@@ -3812,15 +3810,15 @@ Ahahaha.
 You started stroking on your own!-❤*
 To be unable to resist the 
 temptations of such a young girl,
-That's so adorable...❤
+that's so adorable...❤
 Hey- Can I show you how to stroke properly?
 Uh-huh, that's it, stroke the tip real hard
 like this- Aah-
 Well? Did my demonstration get you aroused?
 Teehee... I guess it feels even better when 
-a girl shows you how to masturabte, right?
+a girl shows you how to masturbate, right?
 Ahaha. What a pathetic voice.
-Now just sit stil okay? I'll stroke you
+Now just sit still okay? I'll stroke you
 lots, so just sit back and enjoy-
 Hmm? Gonna cum? Are you going to cum?
 Can't take it anymore? I see, well in that case,
@@ -3863,7 +3861,7 @@ You're losing all your strength,
 but you still can't stop stroking.
 Mm chu-❤ Hora, stroke for me...
 Masturbating while getting kissed feels incredible
-desn't it?
+doesn't it?
 Yeah, it does. There's no need to resist...
 That's it, pew pew-
 Ejaculate in pleasure from my kisses-
@@ -3872,7 +3870,7 @@ Mmm-❤
 初等部生徒：上
 Ahh-❤
 You came so much-❤*
-Senpai's semen is so delicous...
+Senpai's semen is so delicious...
 Ufufu, thank you senpai-❤
 
 <TK8>
@@ -3906,7 +3904,7 @@ You're losing all your strength,
 but you still can't stop stroking.
 Mm chu-❤ Hora, stroke for me...
 Masturbating while getting kissed feels incredible
-desn't it?
+doesn't it?
 Yeah, it does. There's no need to resist...
 That's it, pew pew-
 Ejaculate in pleasure from my kisses-
@@ -3915,7 +3913,7 @@ Mmm-❤
 初等部生徒：上
 Ahh-❤
 You came so much-❤*
-Senpai's semen is so delicous...
+Senpai's semen is so delicious...
 Ufufu, thank you senpai-❤
 
 <TK9>
@@ -3949,7 +3947,7 @@ You're losing all your strength,
 but you still can't stop stroking.
 Mm chu-❤ Hora, stroke for me...
 Masturbating while getting kissed feels incredible
-desn't it?
+doesn't it?
 Yeah, it does. There's no need to resist...
 That's it, pew pew-
 Ejaculate in pleasure from my kisses-
@@ -3958,7 +3956,7 @@ Mmm-❤
 初等部生徒：上
 Ahh-❤
 You came so much-❤*
-Senpai's semen is so delicous...
+Senpai's semen is so delicious...
 Ufufu, thank you senpai-❤
 
 <TK16>
@@ -3982,7 +3980,7 @@ Please...❤
 モルジア：上
 Fufufu, it's as if your reason flew away
 the moment you saw my boobies-*
-Pleading for pleasure infront of your enemy,
+Pleading for pleasure in front of your enemy,
 what a bad boy-❤*
 How would you like to be squeeezed with these 
 breasts I wonder?
@@ -3996,7 +3994,7 @@ can think about. Ufufu-
 
 モルジア：上
 So, you want to ejaculate while being charmed
-and controled by my boobies-
+and controlled by my boobies-
 Tee-hee, what a bad boy-❤
 
 モルジア：上
@@ -4004,8 +4002,9 @@ Ara ara, you wanted to drink from my boobies?
 It's okay, I'll spoil you as much as you like-❤
 
 モルジア：上
-Uwah, to be cuming so much in my boobies...❤
-You colapsed with such a happy smile on your face-
+Uwah, to be cumming so much in my boobies...❤
+You collapsed with such a happy smile 
+on your face-
 
 <TK17>
 レイ：上
@@ -4208,7 +4207,7 @@ But don't worry.
 I'll only do things that feel nice-❤
 
 初等部生徒：上
-Begging and cuming at the same time...❤
+Begging and cumming at the same time...❤
 Did that feel good senpai?-❤
 
 <TK24>
@@ -4233,7 +4232,7 @@ But don't worry.
 I'll only do things that feel nice-❤
 
 初等部生徒：上
-Begging and cuming at the same time...❤
+Begging and cumming at the same time...❤
 Did that feel good senpai?-❤
 
 <TK25>
@@ -4258,7 +4257,7 @@ But don't worry.
 I'll only do things that feel nice-❤
 
 初等部生徒：上
-Begging and cuming at the same time...❤
+Begging and cumming at the same time...❤
 Did that feel good senpai?-❤
 
 <TK26>
@@ -4383,8 +4382,8 @@ equipment.
 
 
 テロップ：中央
-He told us "Sir Sage, has created a magical barrier 
-and locked himself in his room."* 
+He told us "Sir Sage, has created a magical 
+barrier and locked himself in his room."* 
 "Show him this crest to prove help has come from 
 the kingdom, and put these tools and equipment to 
 good use."
@@ -4410,7 +4409,7 @@ I'm afraid we must deal with that first.
 They're just desks, but there's quite a lot of 
 them. It'll take some time to remove them all.
 The enemy will certainly try to disrupt us, so I 
-recommend sending in one of our tougher soldiers 
+recommend sending in our tougher soldiers 
 while patching them up from a distance. 
 That's my thinking at present.
 
@@ -4421,15 +4420,15 @@ If you lower this lever, the door will open,
 or so they say.
 
 ユミル：上
-Immediately past the door is the Sage's room. 
+Immediately past the door is the sage's room. 
 It seems the second floor is where the upper 
 class students reside.  
 Their strength is no joke, so I trust you to 
 guide us well. Beating them or avoiding them 
 is your call to make. 
-Remember, our mission is to rescue the Sage, so 
+Remember, our mission is to rescue the sage, so 
 don't overexert yourself.*
-And as the vice minister told us, 
+And as the chancellor told us, 
 you can use the power of the 
 "King Crest Necklace" to protect us.
 For that reason, do not feel the need to rush 
@@ -4470,12 +4469,12 @@ A quiet girl who usually
 followed after other kids.*
 Before becoming a succubus, she was 
 too scared to even talk to men or boys.*
-But as a succubus, her fear of men disapeared, 
+But as a succubus, she no longer fears men, 
 and now relishes in the feeling of enchanting 
 men and spoiling them with pleasure.
-Like a succubus, her chest also swelled up to
-extreme proportions, which almost caused them
-to burst out of her clothes.
+Her chest also swelled up to extreme proportions, 
+similar to that of a succubus, which almost 
+caused her breasts to burst out of her clothes.
 Though she is not strong, do not be tempted by
 her sweet voice and the caress of her chest.
 
@@ -4485,10 +4484,10 @@ Middle School Girl**
 A diligent, hardworking student. 
 Often looks down upon students and teachers.*
 Her body type is remarkable, and her breasts
-are highly developed. Any men who are wrapped 
+are highly developed. Any man who is wrapped 
 within her chest will be instantly neutralised.
-As he skipped grades, the Sage is her superior 
-even though he's younger. He is also a class 
+As he skipped grades, the sage is her superior 
+even though he is younger. He is also a class 
 above her, so she has a lot of respect for him.
 However, her transformation into a succubus has
 twisted her feelings into a passionate desire
@@ -4500,12 +4499,12 @@ High School Girl**
 A High School Student. A popular student
 known for her beauty, as well as her ability 
 to get good marks.
-After becoming a succubus, her beauty increased
-even more. Now, most men become mindlessly aroused 
-just by staring at her. 
+Becoming a succubus increased her beauty 
+even more. Now, most men become mindlessly 
+aroused just by staring at her. 
 Although she excels at servicing people with her 
 abundant breasts,*
-she also enjoys looking down on people while using 
+she also enjoys looking down on people while using
 her magically enhanced footjobs to make men her 
 slaves. 
 Take care not to become enslaved by her


### PR DESCRIPTION
I have not had a chance to review lines before 3363 for text box requirements. I did try to make sure that the 50 char-per-line rule was observed throughout the whole document via the handy ruler and vertical green gridline you can set. This commit is chiefly for proofreading lines 3363 till the end. Spellchecked the entirety of ch 3.

Notes:
line 108: "Thrusted" is okay, but "thrust" is more common.
line 3389: Line went past 50 char, so I had to move some to the next line.
line 3464: Same issue as line 3389.
line 3501: Keeps the same meaning, but shortens the line to under 50 char.
line 4004: Same issue as line 3389.
line 4429: The chancellor provided the pendant and the instructions on using it, so I changed "vice minister" to "chancellor" for consistency. I hope this is right, because who knows, maybe there's a vice minister in the game I don't know about that is separate from the chancellor?
line 4470: "But as a succubus," modifies the primary school girl, so I slightly reworded the part of the sentence following that.
line 4473-4474: Tried my best to compare her chest size to a succubus'.
line 4500: Similar recommendation to line 4473-4474.