### PR TITLE
QA13 and QA9 done

### DIFF
--- a/English translation/qa13.txt
+++ b/English translation/qa13.txt
@@ -29,7 +29,7 @@ who have had their levels drained are kept.
 Boob Drain Succubus：上
 Ahh❤ What a lot of thick creamy semen❤
 You can't hold back when ejaculating feels
-soo good right?❤
+soo good, right?❤
 
 <AT12>
 Boob Drain Succubus：上
@@ -38,12 +38,12 @@ I'm draining you... You're pretty strong huh?*
 I can't take this anymore. I give up already-
 So please, don't stab me with your sword...
 Please?❤
-Huh? You dont believe succubus when they say 
+Huh? You dont believe succubi when they say 
 "I surrender"? Aww, come on...
 But, can't you think about it?
-Our Queen is gone and all the succubus
+Our Queen is gone and all the succubi
 everywhere are decreasing... If you strike me
-down, there will be no succubus at all-
+down, there will be no succubi at all-
 And if that happens, you'll never be able to
 experience such pleasures ever again...❤*
 And you don't want that, right?
@@ -52,7 +52,7 @@ If you let me go, I'll even live with you
 and do some "nice things" with you every
 single day❤
 I'll give you a Puff-Puff when you wake up❤
-Paizuri after lunch❤、
+Paizuri after lunch❤
 And hot sex after dinner❤
 We can make out as much as you like...❤
 Doesn't that sound fun?*
@@ -93,20 +93,20 @@ things you want to do with me❤
 Once your heart accepts this, you won't be able
 to go against me any longer❤ The pleasure will
 grow and grow, until you become my boob slave❤
-Just the lighest caress of my breasts will cause
+Just the lightest caress of my breasts will cause
 you to give in instantly❤
 
 アクティブ：上
-Ahiee... ahaa...❤
+Ahiee... Ahaa...❤
 
 Boob Drain Succubus：上
-Hora...see?
-You can't do anything else anymore but moan-*
+Hora... See?
+You can't do anything but moan-*
 But not to worry❤
 Even if you ejaculate, you'll have every 
 blissful day to look forward to-*
 Morning, day, or night, we can do pleasent
-things together. Just the two of us❤
+things together. Just the two of us❤*
 Well, you'll be living in a prison, and if you
 run out of levels, you'll be sent out to 
 work but...❤
@@ -123,7 +123,7 @@ Do that and it will all end. I won't be able to
 put you in my prison...❤*
 Ara ara... Aren't you resisting?❤**
 Your face has become slack, and you're moaning
-saying "moreee..."❤*
+saying "Moreee..."❤*
 Looks like your penis gave up from being
 pampered between my boobs❤ Teehee❤*
 How wonderful❤
@@ -145,16 +145,16 @@ I can't take anymore... This is too much for
 a girl like me... So come on, just leave
 me be. Please?❤
 Eh? You were watching earlier?
-And you'd never be tricked by such deceitful words?*
-Ufufu❤
+And you'd never be tricked by 
+such deceitful words? Ufufu❤
 You say that, but your cock is rock hard❤
-You're staring deep into my cleavage too❤
+You're staring deep into my cleavage too❤*
 Hey- Let me drain you with my boobs, just as I
-did to your friend❤ You wanna try it too right?*
+did to your friend❤ You wanna try it too, right?*
 Your friend was moaning so sweetly as I drained
 him. It must have felt really good❤*
 It can't be helped that you want it.
-You haven't fought succubus for so long, and
+You haven't fought succubi for so long, and
 you're already so pent up, right?
 You haven't fought us in so long, you've already
 reached your limit, haven't you?*
@@ -184,12 +184,12 @@ Ahn❤
 You look so spaced out, you can barely attack
 anymore❤
 You're staring at my boobs so much, you can't
-even defend yourself❤
+even defend yourself❤*
 Well then, I'll just rest your legs on my
 lap and...❤
 
 Boob Drain Succubus：上
-...let you experience the bliss you'll be feeling
+...Let you experience the bliss you'll be feeling
 every day from now on❤
 Hora...❤
 
@@ -213,7 +213,7 @@ Boob Drain Succubus：上
 Teehee❤
 Looks like you're taking the time to enjoy
 yourself❤
-Moaning "it feels soo good"...
+Moaning "It feels soo good"...
 Aren't you an obedient boy❤*
 It's okay❤
 Forget all about fighting and your companions,
@@ -229,7 +229,7 @@ Ufufu- Are you gonna cum already?**
 Your penis gave up surprisingly quickly after
 being pampered by my boobs❤*
 Hora- For the final blow, I'll bounce them up and
-down as hard as I can.
+down as hard as I can.*
 Lose your penis in my mind melting breasts, 
 and leak out all your levels❤ Eei❤ Eei❤
 
@@ -250,7 +250,7 @@ Drain Imp：上
 Ufufu, this is my "never ending drain suction
 blowjob"❤*
 Everything will be OK. There's no need to rush-
-After all, you could push little girl
+After all, you could push a little girl
 like me off you easily❤
 So just enjoy yourself until then❤
 
@@ -264,7 +264,7 @@ Just a lit-tle longer-❤*
 I only want a little more of your strength,
 so go ahead and relax❤*
 If you don't like it you can always break free,
-right, mister?❤
+right mister?❤
 
 選択肢：1
 Push her away
@@ -296,7 +296,7 @@ Because your strength stat was lower than the
 enemy, you couldn't shake her off!
 
 アクティブ：上
-A-Ah..ahhh...❤
+A-ah.. Ahhh...❤
 
 Drain Imp：上
 Aha! All your strength has left your body,
@@ -318,7 +318,7 @@ Ahn❤
 Does it feel so good that your body can't support
 itself?
 Don't worry❤
-I'll give you a big hug, and you can lean on me
+I'll give you a big hug, and you can lean on me,
 okay?❤
 Then, I can suck on your penis some more-
 Mmm...❤ Chew...mwah❤ Lick-❤ Slurp❤
@@ -329,18 +329,18 @@ Ufufu- Your hips are trembling❤*
 Is your penis at it's limit?
 Do you think you'll shoot it all right into my
 mouth?
-It's not too late you know-
+It's not too late, you know-
 If you tried your hardest and shook me off you,
 you would be able to defeat me with no regrets❤
 You could always rouse that floppy body of yours
 and push me off, but...❤*
-Ufufu❤ You can put any strength into your arms
+Ufufu❤ You can't put any strength into your arms
 at all❤ Rather than pulling me away, it's
 like your patting me on the head instead❤
 It's like you're praising me for a job well
 done❤ Thank you mister❤*
 Hora, I'm gonna drain everything that you hold
-dear okay? Just shoot all that white pee into
+dear, okay? Just shoot all that white pee into
 my mouth- Pew pew pew❤
 
 Drain Imp：上
@@ -348,7 +348,7 @@ Ufu❤ Gulp...❤**
 Ahhh❤
 That was really tasty❤*
 You might have been strong enough to beat me❤
-I can taste your strength...it's delicious❤*
+I can taste your strength... It's delicious❤*
 I hope that everyone else loses to me as well❤
 Shoot it all into my mouth, and I'll gulp it
 all down❤
@@ -362,10 +362,10 @@ I was pushed into doing guard duty alone.
 Everyone else is feasting inside...*
 I don't even know what's going on in there
 anymore.*
-Hey, you're not as cruel as them are you?**
+Hey, you're not as cruel as them, are you?**
 I don't have it in me to fight anymore.
 Can't you make an exception for me?*
-Y-You won't!?
+Y-you won't!?
 I'm begging you...❤
 I'll even make it up to you, please?
 
@@ -427,7 +427,7 @@ Chu- Kiss-❤
 Playfully biting and sucking your lip...❤
 
 Drain Imp：上
-Ufufu, I'll thank you so more okay?❤
+Ufufu, I'll thank you some more, okay?❤
 Mwah❤ Mwah❤
 
 Drain Imp：上
@@ -437,7 +437,7 @@ Mmwah❤ Kiss❤ Slururp❤
 
 アクティブ：上
 Aahh...❤
-I-It feels soo good...❤
+I-it feels soo good...❤
 
 Drain Imp：上
 So what now?
@@ -449,15 +449,15 @@ Just let me know what you want to do❤
 
 選択肢：1
 More kisses...
-More kisses...*
+More kisses...
 More kisses...
 
 Drain Imp：上
 Teehee❤ Is that so?
 Well then, I guess I can't say no to that,
 now can I?❤
-Thank you very much for making an exception for me❤
-Now go ahead and make a mess for me❤
+Thank you very much for making an exception 
+for me❤ Now go ahead and make a mess for me❤
 Mwah❤ Mmwah❤ Mmchu❤
 
 Drain Imp：上
@@ -485,21 +485,21 @@ TIme to knock you down. Eei❤
 Drain Imp：上
 Ufufu❤
 But unlike my body, the soles of my feet feel
-nice and soft right?❤
+nice and soft, right?❤
 I'll step on you lots with my curvy feet-❤
 
 選択肢：1
-Can't...move...
+Can't... Move...
 Attack desperately!
 
 テロップ：中央
 Due to arousal, you couldn't refuse her request!
 
 選択肢：1
-Can't...move...
+Can't... Move...
 
 Drain Imp：上
-Aaah! I-Impossible! You shouldn't be able to
+Aaah! I-impossible! You shouldn't be able to
 attack like that...!
 Eep, I can't block it!!
 
@@ -521,12 +521,13 @@ You want to give me everything you have,
 don't you?❤ Eei❤
 
 アクティブ：上
-Ahh...ahhh...I can feel myself being drained...❤
+Ahh... Ahhh... 
+I can feel myself being drained...❤
 It f-feels soo good...❤
 
 Drain Imp：上
 Teehee❤
-Looks like the masocist pig likes it❤*
+Looks like the masochist pig likes it❤*
 I think I'll step on your penis even more❤
 I'll squash your cock, and rub my toes over
 the back muscle♪
@@ -582,17 +583,17 @@ Due to arousal, you couldn't refuse her request!
 Can't... Move...
 
 Drain Imp：上
-Aaah! I-Impossible! You shouldn't be able to
+Aaah! I-impossible! You shouldn't be able to
 attack like that...!
 Eep, I can't block it!!
 
 Drain Imp：上
 Aha! Were you indulging in your own fantasies so
-much that you forgot to resist? I'll gonna give you
-a grinding massage with my feet, okay?
+much that you forgot to resist? I'm gonna give 
+you a grinding massage with my feet, okay?
 Are you okay?
 With such a defenseless position, it's like your
-consciousness as fled your mind❤
+consciousness has fled your mind❤
 Then, I'll use my whole body weight and...
 Squish squish squish squish!
 
@@ -616,7 +617,7 @@ from something like this❤*
 Even though I'm only just roughly stepping on you,
 my feet feel so good that you can't get away
 at all❤
-So cute❤
+So cute❤**
 You're so perverted, even as your penis is crushed
 and squeezed between my socks, you can't help but
 fall in love with me❤
@@ -626,17 +627,17 @@ release everything onto my socks❤
 
 アクティブ：上
 Ahiguee❤ A-Aaghh❤
-M-Moree...❤ Aaaaahh❤*
+M-moree...❤ Aaaaahh❤*
 Miss Succubus...❤ Step on me moreee❤
 
 Drain Imp：上
 Teehee❤
-masochistic Pig❤
-You are a very skilled beggar, aren't you?❤
+Masochistic Pig❤
+You're a very skilled beggar, aren't you?❤
 Well then, I'll trample just enough to crush it❤
-Don't worry❤ I'm a succubus, so it won't hurt❤
+Don't worry❤ I'm a succubus, so it won't hurt❤*
 Though the sudden increase in pleasure might
-surprise you❤
+surprise you❤*
 Hora hora hora!
 Let out everything you have onto the soles of
 my feet❤
@@ -645,8 +646,8 @@ Drain Imp：上
 Kyaha❤
 It's pulsing from under my socks❤*
 What a lively penis❤
-You lost mister! And it's all thanks to your friend
-down here❤
+You lost mister! And it's all thanks to your 
+friend down here❤
 Okay! Thanks for the revival!
 With this energy, I can keep on fighting!
 
@@ -662,7 +663,7 @@ And you made such a happy face while doing so...❤*
 Now then, I'll turn you into a boney soldier-
 Eei❤*
 When it comes to being a skeleton, the only
-thoughts you'll have a lewd ones of me-*
+thoughts you'll have are lewd ones of me-*
 You'll live a happy life as my slave until you
 turn into a skeleton❤
 
@@ -675,7 +676,7 @@ Thank you mister- Mwah❤
 Drain Imp：上
 Kyaha! Did you end up cumming already?
 And you were happy when I drained the last drop❤*
-I'm happy you choose me to finish you off❤
+I'm happy you chose me to finish you off❤
 That makes you my captive❤*
 Now then. I'll turn you into a skeleton, so let's
 do our best to distract everyone❤
@@ -690,11 +691,11 @@ Ufufu❤ My drain paizuri felt so good you couldn't
 help but pass out❤*
 And now, I'll drain every last drop out of you,
 until you become a skeleton...❤
-That makes you happy right, human?❤
+That makes you happy, right human?❤
 
 <AT15>
 Drain Imp：上
-Aoughh... Is that...the light of the holy sword 
+Aoughh... Is that... The light of the holy sword 
 Mistress Croix spoke about
 My body feels numb, I can't move...
 
@@ -724,12 +725,13 @@ we please.
 Drain Imp：上
 Lets fight back with the power we've drained!
 With the power I have now, I'll make them fall in
-love with me over several times over!
+love with me several times over!
 
 <AT23>
 Miles：上
-Alright! All the succubus have been taken care of.
-Lets get in there and help these jailed prisoners!
+Alright! All the succubi have been taken care of.
+Lets get in there and help these captured 
+soldiers!
 
 Soldier：上
 Oohhh...**
@@ -744,8 +746,8 @@ They're severely weakened.
 Let's quickly carry them to town!
 
 テロップ：中央
-After seizing the Drain Imp prison,
-we rescued all the captured soldiers inside.*
+We seized the Drain Imp jailhouse, and rescued
+the soldiers captured within.*
 Though their levels were completely drained,
 they weren't fatally harmed, and many lives were
 saved.
@@ -757,15 +759,15 @@ Order.*
 I would hate to imagine what would have happened
 to us if you had not come to our rescue. Please,
 take this as an expression of my gratitude.
-Oh? Are the soldiers doing OK?**
+Oh? Are the soldiers doing okay?**
 Well, I'm ashamed to admit it but...
 Rather than being vengeful, all they can think
 about is the pleasure they experienced.
 Occasionally, they remember the bodies of the
-woman that captured then, and become completely
+women that captured them, and become completely
 useless...
 I think it will be difficult if they are to fight
-succubus again. However, with enough training,
+succubi again. However, with enough training,
 they should be in fighting form again.
 We will not hesitate to put to use the life
 you have given us. So we will do our very best
@@ -781,7 +783,7 @@ as a token of thanks.
 テロップ：中央
 We seized the Drain Imp jailhouse, and rescued
 the soldiers captured within.*
-The rescue was a success, but but by the time we
+The rescue was a success, but by the time we
 broke in, more than a few soldiers had already
 been drained to death.
 
@@ -799,9 +801,9 @@ This should stop any further casualties.
 That's something to be thankful for at least,
 right?
 Drain Succubus... Because they were draining so
-many levels. They were able to survive even after
+many levels, they were able to survive even after
 the Queen's disappearance.
-There may be still other succubus out there in
+There may be still other succubi out there in
 hiding too. We should be careful.
 
 テロップ：中央
@@ -812,7 +814,7 @@ as a token of thanks.
 テロップ：中央
 After failing to rescue the captured soldiers,
 the protagonist was captured.*
-The succubus then imprisoned him, along with
+The succubi then imprisoned him, along with
 everyone else.
 
 Ray：上
@@ -862,7 +864,7 @@ Boob Drain Succubus：上
 Your face is bright red...
 Your penis stiffing and twitching...❤
 It's so cute❤
-OK. That's enough teasing for now.
+Okay. That's enough teasing for now.
 Let's do something that feels good, alright?*
 There's no need to be scared❤
 You might feel yourself getting weaker, but I
@@ -875,14 +877,14 @@ Here we go...❤
 
 Ray：上
 Ahiee❤
-Aaaough... they're so...soft...❤*
+Aaaough... They're so... Soft...❤*
 Aaah, not good...
-Gotta...get away...aaaahh❤
+Gotta... Get away... Aaaahh❤
 
 Boob Drain Succubus：上
 Ufufu-
 You lost yet again to a lesser succubus's boobs❤*
-It's OK❤
+It's okay❤
 Focus all that resistance, and give it all up
 to me❤
 There's no Queen to defeat anymore, so there's no
@@ -894,10 +896,10 @@ them as much as you like❤
 
 Ray：上
 Ahh, ahhh... N-Nh, noo....❤**
-I...I...❤
+I... I...❤
 She's just a lesser succubus but...❤*
 It feels so g-good...❤
-A-Aaahhhh...❤❤
+A-aaahhhh...❤❤
 
 Boob Drain Succubus：上
 Aha❤
@@ -913,23 +915,23 @@ as long as their penis is feeling good,
 they'll go along with anything❤
 
 Ray：上
-Uoough...ahh...m-my hips are melting...❤
+Uoough... Ahh... M-my hips are melting...❤
 
 Boob Drain Succubus：上
 Teehee❤
-Feels good doesn't it? My succubus paizuri❤*
+Feels good, doesn't it? My succubus paizuri❤*
 My soft boobs will caress every inch of your penis
 and go bounce bounce- Squish squish❤*
-You can't resist it at all can you?
-Your hips are trembling❤**
+You can't resist it at all, can you?
+Your hips are trembling❤*
 You don't have to resist-
 Let it all out into my boobs❤*
 Let out your hot semen, and squirt it all into
 my cleavage❤
 
 Ray：上
-Aaugh...aaahh...
-S-So good...❤
+Aaugh... Aaahh...
+S-so good...❤
 
 Boob Drain Succubus：上
 Hora- Time to drain your semen...❤
@@ -944,15 +946,15 @@ You can't help but enjoy it❤
 
 Ray：上
 Ahiee...❤
-M-More...more...❤
+M-More... More...❤
 
 Boob Drain Succubus：上
 Ara ara- You don't want me to stop?
 But then, you won't have any power left, right?
 
 Ray：上
-N-No... Don't stop❤
-Please...❤ Paizuri...more paizuri...❤
+N-no... Don't stop❤
+Please...❤ Paizuri... More paizuri...❤
 
 Boob Drain Succubus：上
 Kuhu❤ Kuhuhu❤**
@@ -963,12 +965,12 @@ me for more on your own❤*
 And I thought you were a hero- How shameful❤
 
 Ray：上
-Ahhh..aah...ahh...it's s-speeding up❤**
-P-Paizuri...❤
+Ahhh... Aah... Ahh... It's s-speeding up❤**
+P-paizuri...❤
 It feels soo good❤❤
 
 Boob Drain Succubus：上
-My true paizuri feels great doesn't it?
+My true paizuri feels great, doesn't it?
 Once you ejaculate, you won't be able to stop❤*
 But don't worry, I won't let you turn into a
 skeleton...❤*
@@ -979,7 +981,7 @@ ultimate pleasure and stop just before you die❤
 Hora hora hora❤
 
 Ray：上
-It won't stop...it won't stop❤❤
+It won't stop... It won't stop❤❤
 Aaaohhh..❤❤
 
 Boob Drain Succubus：上
@@ -1009,23 +1011,23 @@ paizuri, I quickly became their slave.*
 I went through pain and suffering, attempting to
 restore my strength, only to gladly end up letting
 it all out into her breasts.
-I was no ordinary person....the truth is I was
+I was no ordinary person.... The truth is I was
 much, much weaker.
 But, I had no regrets.
 I only desired the bliss of her boobs.
-Nothing else mattered.
+Nothing else mattered.*
 Risking my life hunting the monsters that lived
-around the prison...I increased my levels, and
+around the prison... I increased my levels, and
 then offered them to her over and over again.
 The Queen had been taken care of.
 I didn't need to strength to take care of 
 any big threats... But...
 That was just a foolish excuse. Truthfully,
-the Drain Succubus were growing in strength.
+the Drain Succubi were growing in strength.
 They would be a threat to the kingdom soon.
 And so. The story of the hero of legend came to
 a close as he became a wretched slave, supporting
-lesser succubus with his levels.
+lesser succubi with his levels.
 
 <AT17-2>
 テロップ：中央
@@ -1049,11 +1051,11 @@ someone, we become very strong♪
 Strong enough to even defeat a hero❤ Teehee❤
 
 Ray：上
-Aah...ahh...stop...❤
+Aah... Ahh... Stop...❤
 
 Drain Imp：上
 When I step on your penis with enough absorbed
-magic, it feels like your mind is melting right?*
+magic, it feels like your mind is melting, right?*
 It's okay if it's melting❤
 No one will see❤*
 Your allies are our prisoners.
@@ -1071,19 +1073,19 @@ Teehee❤
 Drain Imp：上
 Kuhu♪
 Your hips feel like they're floating when I
-use my feet to drain you like this right?❤
+use my feet to drain you like this, right?❤
 With the way you're pressing your penis against
-my foot...it's as if you're begging me to
+my foot... It's as if you're begging me to
 drain you more- What a pervert❤
 Can you resist the magical feeling of my soft
 curvy foot? Or will you let me keep teasing your
 penis, and give in to the blissful pleasure?
 If you resist, I won't be able to drain you,
-and you might be able to win right?
-Hora...resist...resist...❤
+and you might be able to win, right?
+Hora... Resist... Resist...❤
 
 Ray：上
-Ahiee❤ _I...I...❤
+Ahiee❤ _I... I...❤
 I can't fight it...❤❤❤
 
 Drain Imp：上
@@ -1099,7 +1101,7 @@ From now on, you'll be my slave, and support me
 with lots of experience points❤
 So, feel my foot rubbing your penis, and let
 your mind go blank.*
-Make a big mess and shoot out all your semen,
+Make a big mess and shoot out all your semen.
 I don't mind❤*
 Hora, squish squish squish❤
 
@@ -1116,16 +1118,16 @@ There's no way you could hate me after
 experiencing something like this, right?❤*
 Aha! You're making such silly expressions,
 Mr. Leader.*
-You have the eyes of a slave you know?
+You have the eyes of a slave, you know?
 Are you aware of it?
 It makes me want to step on you even more❤
 But even when I point it out, you still can't do
-anything about it huh? Teehee❤*
+anything about it, huh? Teehee❤*
 Hora- Little doggy❤
 If you want me to tease your penis more, you
 should ask me properly❤
 Kiss the back of my hand, and pledge your
-slavery to your Imp Mistress...❤*
+loyalty to your Imp Mistress...❤*
 You can do that, right?
 
 Ray：上
@@ -1147,7 +1149,7 @@ Did you like it when I called you a masochist pig?*
 Well then, hora- Squish❤
 
 Ray：上
-Y-Yes...yes❤ M-Mistress!❤❤
+Y-Yes... Yes❤ M-mistress!❤❤
 
 Drain Imp：上
 Squish, squish, squish♪
@@ -1194,34 +1196,34 @@ Teehee❤ Even the hero who overthrew our queen,
 has lost to the pleasure of his penis❤
 Boys can't win against the pleasure, after all.
 If we weren't attacked by reinforcements when we
-fought in that ravine, we couldn't have been
+fought in that ravine, we wouldn't have been
 so battered down...
 We were far from the cliff side, so we somehow 
-got away, but a lot of succubus were wiped out.
+got away, but a lot of succubi were wiped out.
 So, consider this our revenge...❤
-Ahh...omph❤
+Ahh... Omph❤
 
 Ray：上
-A-Ahhh❤
+A-ahhh❤
 
 Drain Imp：上
-Mmm...suck❤**
+Mmm... Suck❤**
 Lots of energy is coming out of the tip of 
 your penis❤*
 Hora...❤ Slurururup❤
 
 Ray：上
-Aaughh❤❤ A-Ahieee...❤
+Aaughh❤❤ A-ahieee...❤
 
 Drain Imp：上
-Your knees are trembling...seems like it feels
+Your knees are trembling... Seems like it feels
 really good, huh?❤
 Teehee❤
 As long as this penis is attached to you, you'll
 never win against bad little demons like us.*
 As soon as your weak member is touched, you get
 this goofy little grin on your face❤
-Boys really are really stupid❤
+Boys really are stupid❤
 Hora hora- Immerse yourself in my wet mouth,
 and give up❤*
 Feel my small tongue flicker along the underside

--- a/English translation/qa13.txt
+++ b/English translation/qa13.txt
@@ -1229,7 +1229,7 @@ and give up❤*
 Feel my small tongue flicker along the underside
 of your penis...*
 When I do this, no matter the man, they all end
-up thrusting their hips forward in seek of more
+up thrusting their hips forward in search of more
 pleasure❤
 And then while their penis is all snug inside my
 mouth, I move back and forth and drain everything
@@ -1241,33 +1241,33 @@ But, even if you break right now, I'm sure it
 will be okay, right?❤*
 If you don't want to break, don't move your penis
 into my mouth when I flick my tongue across it❤*
-Hora... omphhh...suck...❤
+Hora... Omphhh... Suck...❤
 
 Ray：上
 Aahh, ahhh...
 She's so warm, and her tongue is teasing the
 tip...❤
-No...no...I c-can't resist...❤
-oooooghh❤❤
+No... No... I c-can't resist...❤
+Oooooghh❤❤
 
 Drain Imp：上
 Teehee❤
 Let it all leak out of your penis❤
 
 Ray：上
-Aoooughh❤ F-Feels soo goooddd❤❤❤
+Aoooughh❤ F-feels soo goooddd❤❤❤
 
 Drain Imp：上
 Your semen is already building up fast❤
 Soon, it'll be all over❤
-Chew suck slururp...ommmph❤
+Chew suck slururp... Ommmph❤
 
 Ray：上
-A...Ahieee❤
+A... Ahieee❤
 My hips are moving on their own...!!❤
 
 Drain Imp：上
-Mmm...slururup❤
+Mmm... Slururup❤
 Can't stop cumming?*
 It's okay- Don't stop❤
 Let it all out into my mouth❤
@@ -1276,7 +1276,7 @@ Let it all out into my mouth❤
 And so, the hero was squeezed dry by the drain imp
 with extreme pleasure, until his levels were gone.
 But despite that, he was not allowed to die.
-The succubus in the prison always stopped
+The succubi in the prison always stopped
 draining him before death, endlessly playing with
 him as their toy.
 
@@ -1287,12 +1287,12 @@ You could have stayed a hero, but instead you're
 here with us as our toy right?
 
 Ray：上
-Aahh.. aaough...
+Aahh... Aaough...
 
 Boob Drain Succubus：上
 Teehee❤
 I wonder if you've forgotten how to speak?*
-How embarrassing- You're power has been drained
+How embarrassing- Your power has been drained
 so much you've gone stupid, huh?*
 You did a bad thing defeating our queen.
 So now, you'll have to make it up to us.
@@ -1315,25 +1315,25 @@ Ray：上
 Haah...haah...❤
 
 Miles：上
-Ugh...❤ D-Dammit...❤
+Ugh...❤ D-dammit...❤
 
 Nobus：上
-Not good...I'm a-already...❤
+Not good... I'm a-already...❤
 
 アクティブ：上
-A-Ahh...❤
+A-ahh...❤
 
 Drain Imp：上
 Oh- What do we have here?
 You've finally made it inside, only to start
 jerking off to me?
-Taking your penis out...going stroke stroke...
+Taking your penis out... Going stroke stroke...
 Stroke stroke...❤ Teehee❤
 What a bad bad adult you are❤
 You must be so tired out from beating those
 demons- It's so easy to get tempted...❤
 So easy to get aroused❤
-You don't care for this fighting now don't you?
+You don't care for this fighting now, do you?
 If so, then let your mind go blank. You can 
 stroke for as long as you like❤
 Hora- Forget about what's happening around you-
@@ -1358,49 +1358,49 @@ else!
 
 <TK2>
 Ray：上
-Haah...haah...❤
+Haah... Haah...❤
 
 Miles：上
-Ugh...❤ D-Dammit...❤
+Ugh...❤ D-dammit...❤
 
 Nobus：上
-Not good...I'm a-already...❤
+Not good... I'm a-already...❤
 
 アクティブ：上
-A-Ahh...❤
+A-ahh...❤
 
 Drain Imp：上
 Fufu-
 Has another person come to jerk off to my body?*
 You finally made it inside, but your penis is
-throbbing so much...you can't help but jerk off
+throbbing so much... You can't help but jerk off
 to the girl before you♪ What a bad adult❤
-It's OK. It can't be helped after all.
+It's okay. It can't be helped after all.
 It's no surprise you were charmed by me after
 watching your friend jerk off to my body❤
-Hora, aim right out my open mouth and dangling
+Hora, aim right at my open mouth and dangling
 tongue and stroke stroke♪ Stroke stroke♪*
-It feels so good to be entranced right?
+It feels so good to be entranced, right?
 Stroke stroke❤ Stroke stroke❤*
 Now go head and give one last thrust of your
 hips, and let out all your semen...❤
 
 Drain Imp：上
-Ommmph...❤Lick...suck...❤
-Mmm..delishous❤*
+Ommmph...❤ Lick... Suck...❤
+Mmm... Delishous❤*
 You let out just as much as your friend❤
 What a good boy you are❤
 Now I feel even stronger♪
 
 <TK3>
 Ray：上
-Haah...haah...❤
+Haah... Haah...❤
 
 Miles：上
-Ugh...❤ D-Dammit...❤
+Ugh...❤ D-dammit...❤
 
 Nobus：上
-Not good...I'm a-already...❤
+Not good... I'm a-already...❤
 
 アクティブ：上
 A-Ahh...❤
@@ -1409,15 +1409,15 @@ Drain Imp：上
 Aha! You started jerking off to me❤
 Have you already given up?*
 You're supposed to be helping the people inside,
-but here you are jerking off to a succubus for
-dear life❤
+but here you are jerking off to a succubus as if 
+your life depended on it❤
 What a bad little boy❤
 Hora- I'll move my hands together with yours.
 I'll make a loop with my hand and...
 Stroke stroke❤ Stroke stroke❤ Teehee❤
-Does it feel good to shake your hips?
+Does it feel good to shake your hips?*
 You're so cute❤
-Are you about to cum already?
+Are you about to cum already?*
 The fact that you're not even stroking that fast
 and can't resist shows how pathetic you are❤
 Hora, go ahead and let it all out❤
@@ -1431,32 +1431,32 @@ Now I can take down all the intruders!
 
 <TK4>
 Ray：上
-Haah...haah...❤
+Haah... Haah...❤
 
 Miles：上
-Ugh...❤ D-Dammit...❤
+Ugh...❤ D-dammit...❤
 
 Nobus：上
-Not good...I'm a-already...❤
+Not good... I'm a-already...❤
 
 アクティブ：上
-A-Ahh...❤
+A-ahh...❤
 
 Drain Imp：上
 Aha! Masturbating again?
 It looks like all the heroic knights will do
 whatever their penis tell them to❤
 You're supposed to be helping the people inside,
-but you're here in front of me going stroke stroke,
-stroke stroke❤
+but you're here in front of me going stroke 
+stroke, stroke stroke❤
 Once you start stroking, it feels so good you
-can't stop right? Come here, I want to get a real
+can't stop, right? Come here, I want to get a real
 good look at your traitorous penis, bad boy❤
 I'll watch you jerk off to me❤
 Ufu- Does it make your dick twitch when a young
 girl like me calls you a "bad boy"?
 What a pervert❤
-Perverted penises ejaculate when I'm teasing them,
+Perverted penises ejaculate when I'm teasing them.
 Just before they cum, I pinch the tip like this❤
 Hora, I'll flick the tip of your penis, and you'll
 leak out all your semen❤ Hand over all your
@@ -1471,23 +1471,24 @@ Now I can use this to take out the intruders!
 
 <TK5>
 Ray：上
-Haah...haah...❤
+Haah... Haah...❤
 
 Miles：上
-Ugh...❤ D-Dammit...❤
+Ugh...❤ D-dammit...❤
 
 Nobus：上
-Not good...I'm a-already...❤
+Not good... I'm a-already...❤
 
 アクティブ：上
-A-Ahh...❤
+A-ahh...❤
 
 Drain Imp：上
 Teehee❤ What's the matter?
 You've stopped fighting and started jerking off❤*
-You're forgotten yourself and stroking desperately❤
+You're forgotten yourself and stroking 
+desperately❤*
 All that power I got from draining must have 
-increased my lewd aura and put you in a trance❤
+increased my lewd aura and put you in a trance❤*
 When your mind is so charmed and vacant, it's
 only natural to fall in love with me❤*
 Hora- Stroke your penis as your favourite kid
@@ -1495,13 +1496,13 @@ watches you- Stroke stroke❤ Stroke stroke❤*
 I'm gonna steal all your precious power, okay?❤
 But I'm your favourite child, so nothing would
 make you happier❤ It's the best feeling ever...❤
-Aha! You're nodding wildly...you're  just too
+Aha! You're nodding wildly... You're just too
 cute!❤*
 Hora- Kneel before me...❤
 I'll pat you on the head, so pour out as much as
-you can for me OK?
+you can for me, okay?
 That's it, just look into my eyes.
-Stroke stroke stroke stroke❤
+Stroke stroke, stroke stroke❤
 Let it all out...❤
 
 Drain Imp：上
@@ -1512,20 +1513,21 @@ Now I can use this to take out the intruders!
 
 <TK6>
 Ray：上
-Haah...haah...❤
+Haah... Haah...❤
 
 Miles：上
-Ugh...❤ D-Dammit...❤
+Ugh...❤ D-dammit...❤
 
 Nobus：上
-Not good...I'm a-already...❤
+Not good... I'm a-already...❤
 
 アクティブ：上
-A-Ahh...❤
+A-ahh...❤
 
 Drain Imp：上
-Aha!❤ Have you fallen in love with me too mister?
-You stopped fighting, and started stroking❤*
+Aha!❤ Have you fallen in love with me too, 
+mister? You stopped fighting, and started 
+stroking❤
 Your friends are out fighting, but you just don't
 care anymore. You can't see anything but me, the
 love of your life...❤
@@ -1538,8 +1540,8 @@ When you cum, I'll get a big power up and
 your friends would probably be in big trouble.
 But, you just can't hold back anymore, right?❤
 When you jerk off in front of your true love, 
-it feels so good...you can't hold back...❤
-Hora...cum...cum...❤ Let it all out...❤
+it feels so good... You can't hold back...❤
+Hora... Cum... Cum...❤ Let it all out...❤
 
 Drain Imp：上
 Teehee❤ Squirt squirt squirt❤
@@ -1549,16 +1551,16 @@ Now I can take down all the intruders!
 
 <TK7>
 Ray：上
-Haah...haah...❤
+Haah... Haah...❤
 
 Miles：上
-Ugh...❤ D-Dammit...❤
+Ugh...❤ D-dammit...❤
 
 Nobus：上
-Not good...I'm a-already...❤
+Not good... I'm a-already...❤
 
 アクティブ：上
-A-Ahh...❤
+A-ahh...❤
 
 Boob Drain Succubus：上
 Ara ara... So you couldn't help but jerk off while
@@ -1573,29 +1575,29 @@ Even if a cute boy like you loves to stare at
 pretty boobies, there's nothing wrong about that❤
 Hora, I'll squeeze your face between them, okay?❤
 Stroke that penis and give yourself a nice,
-blissful ejaculation as I fill you with happiness❤
-Puff-Puff...❤ Puff-Puff...❤
+blissful ejaculation as I fill you with 
+happiness❤ Puff-Puff...❤ Puff-Puff...❤
 
 Boob Drain Succubus：上
 Ufu- Ooh It's all shooting out❤
-Mmm...what delicious energy❤*
-It seems you've fallen...and with a
+Mmm... What delicious energy❤*
+It seems you've fallen... And with a
 blissful expression too❤
 Hora, any other boys wanna come over?
 I'll let you jerk off sweetly just. Like. Him❤
 
 <TK8>
 Ray：上
-Haah...haah...❤
+Haah... Haah...❤
 
 Miles：上
-Ugh...❤ D-Dammit...❤
+Ugh...❤ D-dammit...❤
 
 Nobus：上
-Not good...I'm a-already...❤
+Not good... I'm a-already...❤
 
 アクティブ：上
-A-Ahh...❤
+A-ahh...❤
 
 Boob Drain Succubus：上
 Welcome! Welcome!❤
@@ -1609,9 +1611,9 @@ There's no need to get so flustered❤
 All boys are like that.
 Hora, I'll hold your head between them.
 Breathe in their sweet scent and stroke your
-penis lots, OK?❤
-Fufu- Now you can't stop stroking until I say so-❤
-Just let the pleasure sweep your mind away❤*
+penis lots, okay?❤
+Fufu- Now you can't stop stroking until I say 
+so-❤ Just let the pleasure sweep your mind away❤*
 Buried in my boobs, filled with happiness...
 Stroke stroke❤ Stroke stroke❤*
 Hora- Cum already. You can't fight it❤
@@ -1621,9 +1623,9 @@ Puff-Puff...❤ Puff-Puff...❤
 Stroke stroke❤ Stroke stroke❤
 
 Boob Drain Succubus：上
-Mmm- Cum...cum...❤
+Mmm- Cum... Cum...❤
 You must have been very satisfied to pour out
-this much❤ Ahh...what delicious power❤
+this much❤ Ahh... What delicious power❤
 Is there anyone else like this boy who would
 like to request my aid? I'd be happy to help,
 no matter who you are❤
@@ -1637,11 +1639,12 @@ Oough...❤ Please...❤
 I can't take this anymore...❤
 
 Nobus：上
-Not good...I'm a-already...❤ I only looked and...❤
-Oough...p-please...❤
+Not good...I'm a-already...❤ I only looked 
+and...❤
+Oough... P-please...❤
 
 アクティブ：上
-Ooh...please make me feel good...❤
+Ooh... Please make me feel good...❤
 I'm begging you...❤
 
 Drain Imp：上
@@ -1660,17 +1663,18 @@ Oough...❤ Please...❤
 I can't take this anymore...❤
 
 Nobus：上
-Not good...I'm a-already...❤ I only looked and...❤
-Oough...p-please...❤
+Not good... I'm a-already...❤ I only looked 
+and...❤
+Oough... P-please...❤
 
 アクティブ：上
-Ooh...please make me feel good...❤
+Ooh... Please make me feel good...❤
 I'm begging you...❤
 
 Drain Imp：上
 Teehee❤
 You've stopped advancing just to ask me for more?*
-I though the heroic knights are suppose to be
+I though the heroic knights are supposed to be
 cautious, and yet you're doing this...
 How unsightly❤
 Don't worry❤
@@ -1685,11 +1689,12 @@ Oough...❤ Please...❤
 I can't take this anymore...❤
 
 Nobus：上
-Not good...I'm a-already...❤ I only looked and...❤
-Oough...p-please...❤
+Not good... I'm a-already...❤ I only looked 
+and...❤
+Oough... P-please...❤
 
 アクティブ：上
-Ooh...please make me feel good...❤
+Ooh... Please make me feel good...❤
 I'm begging you...❤
 
 Drain Imp：上
@@ -1710,11 +1715,12 @@ Oough...❤ Please...❤
 I can't take this anymore...❤
 
 Nobus：上
-Not good...I'm a-already...❤ I only looked and...❤
-Oough...p-please...❤
+Not good... I'm a-already...❤ I only looked 
+and...❤
+Oough... P-please...❤
 
 アクティブ：上
-Ooh...please make me feel good...❤
+Ooh... Please make me feel good...❤
 I'm begging you...❤
 
 Boob Drain Succubus：上
@@ -1736,18 +1742,18 @@ Nobus：上
 Hey Ray, you got a moment?
 That report...*
 Ahh, about the search for the remaining
-succubus? We were searching the northern forest.
+succubi? We were searching the northern forest.
 It was then...
 
 Soldier：上
-H-Help! You have to help me!
+H-help! You have to help me!
 
 Nobus：上
 ...!
 Hey, is everything okay?
 
 Soldier：上
-O-Our group was captured by succubi.
+O-our group was captured by succubi.
 And they're keeping us at a succubus prison to the
 north of here!
 They keep draining our levels over and over...
@@ -1771,12 +1777,12 @@ And then while accompanying that poor soldier...**
 At first he seemed calm, but as we got closer
 to the village, he started acting more and more
 suspiciously.
-And in the end, the violent raging and shouting
-saying "please take me back..."*
+And in the end, he raged violently and kept 
+shouting "Please take me back!"*
 A few of us had to hold him down. I honestly
 have no idea how we carried him this far.*
 He's currently resting in the underground
-detention center until his condition dies down.*
+detention center until his condition settles down.*
 About this succubus prison thing, we can't just
 let it slide. What do you say, Ray?
 
@@ -1796,7 +1802,7 @@ Ray：上
 Miles：上
 Is that the Drain Succubus prison that soldier
 mentioned?*
-It's about the side of the small fort.
+It's about the side of a small fort.
 Who knows how many people are being held inside?
 
 Drain Imp：上
@@ -1823,7 +1829,7 @@ but we should rescue them as soon as possible!
 
 Miles：下
 Hey, Nobus.
-You just said "my queen" again.
+You just said "My queen" again.
 Is it really okay to be referring to the Succubus
 Queen like that? Are you sure you're not still
 affected by anything?

--- a/English translation/qa14.txt
+++ b/English translation/qa14.txt
@@ -1,12 +1,12 @@
 <PL1>
 テロップ：中央
-回復の魔法陣だ**
-周囲の味方の体力が回復する！
+It's a healing circle.**
+The HP of surrounding allies has been restored!
 
 テロップ：中央
-回復の魔法陣だ**
-周囲の味方の体力が回復する！
-（ヒーラーが使用したため効果範囲がアップ！）
+It's a healing circle.**
+The HP of surrounding allies has been restored!
+(The healer increased the range of effect!)
 
 <AT0>
 テロップ：中央

--- a/English translation/qa9.txt
+++ b/English translation/qa9.txt
@@ -35,7 +35,7 @@ The defense security system was turned on!
 
 <AT1>
 Black Marketeer：上
-Ugh, I'm done for aren't I?
+Ugh, I'm done for, aren't I?
 This is it...*
 Hey, Mr. Capital Soldier...❤
 See this medicine?
@@ -46,7 +46,7 @@ many times more sensitive than ever before❤
 If I stroke you after you've swallowed this,
 you'll feel so good that you'll cum until you
 go crazy...❤
-It's an iteam that would enable even a regular
+It's an item that would enable even a regular
 human female to milk a man to death...❤
 Well, why don't you try imagining it?
 If a regular human woman could give someone so
@@ -75,7 +75,7 @@ Ahh, and you would have tasted happiness like no
 other... What a shame...
 
 Black Marketeer：上
-Ufufu- So, since you're not moving after I get
+Ufufu- So, since you're not moving after I got
 this close to your face, it must mean you want to
 enjoy my medicine, don't you?
 Well then, as you wish....
@@ -88,12 +88,12 @@ That's it- Gulp it down❤ Good boy❤
 
 Black Marketeer：上
 A succubus's saliva is a potent aphrodisiac, so
-it's effects combined with the medicine could
-lead to uncontrolable results...❤
+its effects combined with the medicine could
+lead to uncontrollable results...❤
 
 アクティブ：上
 Aaaaough, aah-aaaaaaahh❤
-W-What wha....❤ Ahhhh...❤❤
+W-what wha....❤ Ahhhh...❤❤
 
 Black Marketeer：上
 Ufufu- It seems to be taking effect immediately❤
@@ -108,10 +108,10 @@ Now then, as you pliantly shake your hips, I'll
 service and milk you with my hands, alright?*
 I'll go easy and stroke you slowly at first...
 Wrap my fingers around you and slowly...
-stroke...stroke...❤
+Stroke... Stroke...❤
 
 アクティブ：上
-Aahhh ahieee...❤ A-Aoughhh-❤
+Aahhh ahieee...❤ A-aoughhh-❤
 
 Black Marketeer：上
 Ara, just a little touch, and you jumped up
@@ -119,16 +119,17 @@ like that. Did having your sensitive penis
 stroked feel a little too good?
 I only stroked you once, but it feels better than
 being stroked normally 10 times...❤ And if you
-lose concentration...100 times more pleasureable❤
+lose concentration... 
+100 times more pleasureable❤**
 With such terrifying pleasure, if I jerk you off
 more and more at this speed, your nerves will
 probably end up breaking in no time, right?❤
 Teehee-
-It's OK. Even if they break...❤*
+It's okay. Even if they break...❤*
 Your life ends here.
 Nothing can save you anymore.*
 So then, why not keep cumming until you die?
-Over and over again...❤
+Over and over again...❤*
 Let the otherworldly pleasure take over your
 mind. Hora- Stroke stroke stroke❤
 Stroke stroke stroke❤
@@ -139,9 +140,9 @@ Aough aaoagh❤❤
 Black Marketeer：上
 Aha! Pew pew pew- Let it all out❤
 But, I'm not going to stop❤*
-You're going to keep cumming until you die❤
+You're going to keep cumming until you die❤**
 Now I'm going to rub the head with my palm,
-and...stroke stroke stroke stroke stroke
+and... Stroke stroke stroke stroke stroke
 stroke...❤
 
 Black Marketeer：上
@@ -166,12 +167,12 @@ him mad as he came helplessly with my handjob❤
 How good would it feel to be happily milked like
 that, gasping and moaning to the brink of death?❤
 Don't you envy him?
-Don't you want to experience it?*
+Don't you want to experience it?**
 Say the word, and I'll present you with the
-highest of pleasures, in the same way as before❤
+highest of pleasures, in the same way as before❤*
 Teehee❤ You're hesitating, aren't you?
 Your arms are trembling❤*
-Stop this fighting...I'll show you what
+Stop this fighting... I'll show you what
 otherworldly pleasure tastes like❤
 
 選択肢：1
@@ -188,7 +189,7 @@ Black Marketeer：上
 Gah! What a shame...
 
 Black Marketeer：上
-Ufufu- So, since you're not moving after I get
+Ufufu- So, since you're not moving after I got
 this close to your face, it must mean you want to
 enjoy my medicine, don't you?
 Well then, as you wish....
@@ -202,11 +203,11 @@ taste that makes you want even more kisses❤
 But, that was just to administer your medicine.
 Our tongues may have coiled around each other like
 lovers, but that was only to get you to swallow
-the pill...to let your guard down❤
+the pill... To let your guard down❤
 
 アクティブ：上
 Aaaaough, aah-aaaaaaahh❤
-W-What wha....❤ Ahhhh...❤❤
+W-what wha....❤ Ahhhh...❤❤
 
 Black Marketeer：上
 Ufufu- It's taking effect immediately❤
@@ -217,30 +218,30 @@ on their own- Hump hump- Hump hump-❤*
 Even rubbing against the air feels amazing,
 doesn't it?❤*
 Your slutty hips are shaking as if hungry for
-pleasure❤ Teehee❤ I should tend to it's lust❤*
-Your quivering penis...I'll milk and serve it with
-my hands*
+pleasure❤ Teehee❤ I should tend to its lust❤*
+Your quivering penis... 
+I'll milk and serve it with my hands*
 I'll go easy and stroke you slowly at first...
 Wrap my fingers around you and slowly...
-stroke...stroke...❤
+Stroke... Stroke...❤
 
 アクティブ：上
-Aahhh ahieee...❤ A-Aoughhh-❤
+Aahhh ahieee...❤ A-aoughhh-❤
 
 Black Marketeer：上
 Ara, just a little touch caused you to convulse...
-And you ended up getting the floor all dirty
+And you ended up getting the floor all dirty,
 didn't you?❤
 Was that at least 2 or 3 strokes of pleasure?
 Well, enough to give you a premature ejaculation❤*
-Your knees buckling...leaning closer in to me...
+Your knees buckling... Leaning closer in to me...
 I think the enhanced pleasure is controling your
 hips and making them go crazy❤
-It's OK. Even if you break...❤*
+It's okay. Even if you break...❤*
 Your life ends here.
-Nothing that can save you anymore.*
+Nothing can save you anymore.*
 So then, why not keep cumming until you die?
-Over and over again...❤
+Over and over again...❤*
 Let the otherworldly pleasure take over your
 mind. Hora- Stroke stroke stroke❤
 Stroke stroke stroke❤
@@ -257,7 +258,7 @@ despair and esctasy❤ How wonderful❤*
 Cum- Keep cumming until you die❤
 Let it all out into my hands❤*
 Hora, I'll squeeze the head with my fingers and...
-stroke stroke stroke stroke stroke stroke...❤
+Stroke stroke stroke stroke stroke stroke...❤
 
 Black Marketeer：上
 Teehee❤ What an amazing amount you ejaculated❤
@@ -288,9 +289,9 @@ by one.
 Mizuhide：上
 Precisely.
 Let's leave the rest for the other soldiers to
-take care of it.
+take care of.
 Now that we've cut off the root of the problem,
-things should eventually come to an end.
+things should eventually come to an end.*
 Thank you very much for your cooperation everyone.
 Good work.
 
@@ -300,16 +301,16 @@ Ufufu- Looks like I win, capital soldiers-**
 Struck by whips, stroked by hands...
 Letting out all your semen...*
 You easily ended up submitting to the evil
-succubus didn't you? Teehee-
+succubus, didn't you? Teehee-
 
 Ray：上
 Aooughhh...❤
 
 Black Marketeer：上
 Now, before I milk you dry...
-First, state your afflictions.*
+First, state your affiliation.*
 I wonder what kind of Chilvaric Order you
-soldiers bellong to?
+soldiers belong to?
 
 Mizuhide：上
 Urgh, we have no obligation to answer to...
@@ -326,11 +327,11 @@ The rush of intense pleasure that flows from where
 it hurts ends up robbing a man's willpower right
 away-
 And you're already feeling it too, sweet boy-
-The pleasure has already taken your mind...and
+The pleasure has already taken your mind... And
 you can't think of anything at all, right?
 
 Mizuhide：上
-Ahh- W-Wha...❤
+Ahh- W-wha...❤
 
 Black Marketeer：上
 Now then. Tell me your rank.**
@@ -345,13 +346,15 @@ Looks like my catch is even bigger than I
 expected- I really lucked out on this one♪
 
 Mizuhide：上
-Ooohh, P-Please... You promised you'd...❤
+Ooohh, p-please... You promised you'd...❤
 
 Black Marketeer：上
 Shut up.**
-Don't disturb someone while they're thinking, OK?**
-This whip...entrances foes with pleasure when magic
-passes through it-*
+Don't disturb someone while they're thinking, 
+okay?*
+This whip... 
+Entrances foes with pleasure when magic passes 
+through it-
 However, if I don't use magic, it only inflicts
 pain.*
 Perhaps you'd like to be beaten normally?
@@ -363,10 +366,10 @@ Ahiee!!
 Black Marketeer：上
 Teehee- Why have you gotten so big after being
 whipped normally?*
-I had no idea my little boy was such a masocist-
+I had no idea my little boy was such a masochist-
 
 Mizuhide：上
-Aaugh!! Aoough...M-Mistress...❤
+Aaugh!! Aoough... M-mistress...❤
 
 Black Marketeer：上
 That's right. I am your mistress.
@@ -375,24 +378,24 @@ And for your reward, I'll infuse it with lots
 of magic and...!
 
 Mizuhide：上
-Ahiee❤Aaahaaahhhh...❤
+Ahiee❤ Aaahaaahhhh...❤
 
 Black Marketeer：上
 Psh, you let out your energy and ended up
-fainting. How dissapointing.
+fainting. How disappointing.
 
 Black Marketeer：上
 The commander has already been squeezed to death
 with my special medicine, and the rest of
 the soldiers are my prisoners- 
 It was a little startling at first, but in the
-end they're only humans-
+end, they're only humans-
 They're no match for us♪
 Now then, let's close up this shop and relocate
 to another location. Get ready to leave
-quickly everyone!
+quickly, everyone!
 
- Lotion Succubus：上
+Lotion Succubus：上
 Yes Shop Manager!
 Understood.
 
@@ -401,7 +404,7 @@ And with that, all that's left is you,
 Mr. Commander.
 
 Ray：上
-Ooh...oohh...
+Ooh... Oohh...
 
 Black Marketeer：上
 Teehee- Though your companions have fallen beside
@@ -415,11 +418,11 @@ Now then, I'll milk you to death with my hands❤
 Black Marketeer：上
 By joining my hands together like this, I'll make
 a tube with the palms of my hands.*
-...and pour lots of aphrodisiac inside.**
+...And pour lots of aphrodisiac inside.**
 What do you think?
-A devilish hand pussy...that will milk out a
+A devilish hand pussy... that will milk out a
 man's life force in seconds.
-And your rock hard penis...is slowly entering
+And your rock hard penis... is slowly entering
 it...❤
 
 Ray：上
@@ -427,33 +430,34 @@ Ahiee, aah! Aaahhh...❤
 
 Black Marketeer：上
 Ufufu, it's iresistable having my ten fingers rub
-and massage your penis isn't it?*
+and massage your penis, isn't it?*
 It feels so good your hips can't help but move
 on their own. Frantically rubbing your male
 genitalia into my sensual finger onahole pussy... 
-How pathetic.
-Your penis...rubbing against my cushion-like
-fingers...pushing through the slick aphrodisiac...
-Hump hump...❤ Hump hump...❤
-Your face has completely melted-*
+How pathetic.**
+Your penis... rubbing against my cushion-like
+fingers... pushing through the slick 
+aphrodisiac... Hump hump...❤ Hump hump...❤
+Your face has completely melted-**
 But no matter how many times you shake your hips,
 it's all meaningless.*
 Even though doing it only speeds up your own
-death, you won't stop. What a truely stupid
+death, you won't stop. What a truly stupid
 human. Teehee❤
 Ara ara, when I ridicule you while making my hand
-pussy ever so smaller, your body trembles...❤
-It feels so good you can barely seem to stand huh?
+pussy ever so smaller, your body trembles...❤*
+It feels so good you can barely seem to stand, 
+huh?**
 Don't worry. Even if your legs give way and you
 fall to the ground, I'll straddle you and keep
 milking you with my hands until you're empty.
-It'll be like being mounted, but with a a hand
-pussy. It'll feel good for sure won't it?
+It'll be like being mounted, but with a hand
+pussy. It'll feel good for sure, won't it?*
 So just give in and let your legs give way-
 Hora, hora...❤ Thrusting in and out of my
 hand onahole... Squelch, squelch...❤
 Teehee❤
-Let out all your energy into in my hands.
+Let out all your energy into in my hands.*
 Squelch, squelch...❤
 Squelch, squelch...❤
 
@@ -466,7 +470,7 @@ It's like you attempted to make my hands
 pregnant-❤
 
 Black Marketeer：上
-And now, if I take your penis that has just came,
+And now, if I take your penis that has just cum,
 and squeeze my hand pussy tightly...❤*
 And move my fingers like this...
 Rubby rubby...❤ Rubby rubby...❤
@@ -476,11 +480,11 @@ Ahiee...❤ It feels soo good-❤**
 Ah, ah! I-I can't stop...❤
 
 Black Marketeer：上
-Teehee❤ My fingers are sweetly pleading you
+Teehee❤ My fingers are sweetly pleading you,
 saying "Let out your semen❤", and you can't
-resist at all can you?❤
+resist at all, can you?❤
 Just continue getting milked like this...❤
-Splunk your life...your everything...into my
+Splunk your life... your everything... into my
 hands❤
 
 Black Marketeer：上
@@ -488,11 +492,11 @@ Fufu, you ended up fainting.
 You couldn't even resist being squeezed by my
 hand pussy for five minutes❤
 You're just a boy who can't even resist having
-his penis held❤
+his penis held❤*
 Losing to a foe who doesn't even have a weapon...
 You can't be considered a swordsman at all.
 
- Lotion Succubus：上
+Lotion Succubus：上
 What should we do with the fainted men,
 Shop Manager?
 
@@ -502,13 +506,13 @@ Watch them as their energy is milked...
 Only keep those with good sperm.
 Fortunately, a human male has many uses.
 If they aren't good enough, we can use them for
-our experiemental goods.
+our experimental goods.
 Like those medicines that were just finished-
 Administer those to them... Ufufu...❤
 I'm sure we'll have some use for them after that-
 
 <AT6-2>
- Lotion Succubus：上
+Lotion Succubus：上
 Ehehe, can't you move any more?
 That's because I made you squirt-
 Ejaculating makes your body relax❤
@@ -516,9 +520,9 @@ Ejaculating makes your body relax❤
 Ray：上
 Aouugh...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Teehee❤ You're not resisting at all when I bully
-your penis with my slimy lotion huh?
+your penis with my slimy lotion, huh?
 I'm so happy you have such a weak penis❤
 Hey, Mr. Soldier-
 Do you still think this lotion is a bad thing?*
@@ -527,36 +531,36 @@ feels soo nice and pleasureable, right?*
 Do you still think it's a bad thing?
 
 Ray：上
-A-Ah! O-Obviously...
+A-ah! O-obviously...
 Succubus made items are...!
 
 Ray：上
-Aah❤ S-Stopp... Aaahhh❤
+Aah❤ S-stopp... Aaahhh❤
 
 Ray：上
 Ooh, ooohhhh....❤❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Kuhu❤
 Whenever I stroke the head with my hand, you
-suddenly stop talking-❤
+suddenly stop talking-❤*
 Even though you have to say it's bad, when your
 penis is squeezed and rubbed, you can't help
 but think "I wanna be stroked more❤", right?
-Hora, if you say no I'll stop OK?
+Hora, if you say no, I'll stop, okay?
 But do you really want to?*
-Don't you want me to massage...❤ and massage...❤
+Don't you want me to massage...❤ And massage...❤
 Your sensitive penis tip?
 
 Ray：上
 Ahiee❤ Ooh, oohhhh...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Aha❤
 Your hips are twitching- It's so cute!❤*
 You're answering with those shaking hips, right?❤
 If our items were so bad, then there's no way a
-soldier...an ally of justice would want this-❤
+soldier... an ally of justice would want this-❤
 I'm just slowly teasing your penis with my hand,
 but your penis feels like it's melting...❤
 This is just a tool that makes boys happy-❤
@@ -564,42 +568,42 @@ Isn't that right? Teehee❤
 
 Ray：上
 Aouugh...❤
-D-Don't tease me...❤*
-I-It's not, bad... it's not bad...!❤
-So please... stroke it faster.. aah❤
+D-don't tease me...❤*
+I-it's not, bad... It's not bad...!❤
+So please... Stroke it faster... Aah❤
 Aaaaaahh❤❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Kyahaha! As you wish, I'll jerk you off at
 high speed! Squish squish squish-❤*
 Squelch squelch♪ Squelch squelch♪
 What a wonderful sound❤*
-Even when I jerk you off like this...because of
-the lotion, it doesn't hurt one bit right?❤*
-Does it feel good getting jerked off my a female
-enemy? It feels good doesn't it?*
+Even when I jerk you off like this... Because of
+the lotion, it doesn't hurt one bit, right?❤*
+Does it feel good getting jerked off by a female
+enemy? It feels good, doesn't it?*
 The slack expression you're showing is pathetic❤
 A girl like me is going to end up making you
 cum with her hand. Kyahaha♪ How weak-❤
 
 Ray：上
 Augh❤ Ahh, ahieee❤❤
-T-Too muchh!!❤*
-N-Noo... I'm cumming again...!❤❤
+T-too muchh!!❤*
+N-noo... I'm cumming again...!❤❤
 Ahhhh❤
 
- Lotion Succubus：上
-It's OK. Let it out, fool❤
+Lotion Succubus：上
+It's okay. Let it out, fool❤
 Hora, I'll even stroke the tip for you.
 Stroke stroke stroke stroke♪
 
- Lotion Succubus：上
+Lotion Succubus：上
 Teehee❤
 You ejaculated like a fountain and ended up
-fainitng huh?❤ As expected, one hand is more than
-enough for you♪
+fainting huh?❤ 
+As expected, one hand is more than enough for you♪
 
- Lotion Succubus：上
+Lotion Succubus：上
 Hey- Hey Shop Keeper-
 Is it okay to feed off this boy?*
 His energy is pretty delicious♪
@@ -608,10 +612,10 @@ I think he might be a really strong soldier-
 Black Marketeer：上
 Go ahead. Do as you like.
 
- Lotion Succubus：上
+Lotion Succubus：上
 Yaay-♪**
-Well then, let's keep going until you dry up, OK?
-Mr Soldier with a weak penis♪
+Well then, let's keep going until you dry up, 
+okay? Mr Soldier with a weak penis♪
 Teehee❤
 
 <AT6-3>
@@ -623,20 +627,21 @@ Don't you think so too, Mr. Commander?*
 Hora, like this. Psheww---❤
 
 Ray：上
-Haahh..❤
-Ohh, a-amazing..❤
+Haahh...❤
+Ohh, a-amazing...❤
 
 Perfume Succubus：上
 Kuhu, You got all lovey dovey right away from
 having some perfume sprayed on you-*
 Now then, let's get you milked while your mind is
-all fuzzy alright?*
+all fuzzy, alright?*
 Could you stand up?
 Come on, on your feet.*
 When you sniff this aroma, you can't stop my words
-from penetrating deep into your mind right?*
+from penetrating deep into your mind, right?*
 That's right... Good boy-
-Now then, I'll just press you against the wall...❤*
+Now then, I'll just press you against the 
+wall...❤
 I'll milk everything out of you properly with
 my sexy thighs.
 
@@ -647,42 +652,42 @@ Perfume Succubus：上
 Kuhu-
 You've become rock hard only after one pump❤*
 Being squeezed by my thighs feels super
-good doesn't it?*
+good, doesn't it?*
 It's okay- Don't bother trying to endure it-
 Hora, I'll move my smooth silky legs back and
 forth, rubbing your lovely penis between them.
 When you're rubbed by my thighs, it feels like
-you could melt away right?*
-Squish...squish...❤ Squish...squish...❤
+you could melt away, right?*
+Squish... Squish...❤ Squish... Squish...❤
 Squeeze...❤
 
 Perfume Succubus：上
 Aha! What a lovely expression❤
-Your eyes have already become unfocused right?*
+Your eyes have already become unfocused, right?*
 Exposed to pheromones, body tightly embraced,
-and your penis...wrapped up between my
+and your penis... wrapped up between my
 curvy thighs.
-It's pure happiness right?
-Don't worry. Enjoy yourself as much as ou can
+It's pure happiness, right?
+Don't worry. Enjoy yourself as much as you can
 while we cuddle together.
 Let the sinful drugs make your mind go blank
 and happy. You probably won't be able to go back
-after experiencing it but that's OK, right?
+after experiencing it but that's okay, right?
 That's right- You're nodding so intently.
 So cute-❤*
 Hora, move your hips back and forth.
-Let out all your semen in one big splurt, OK?*
+Let out all your semen in one big splurt, okay?*
 There's no need to fight it.
 Entrust your body to the bliss...❤*
 Rub yourself between my thighs as you slap...
-slap...slap...❤*
+Slap... Slap...❤*
 That's it, just like that...❤
 Pewwww--❤
 
 Perfume Succubus：上
 Fufu, you ended up letting everything out
 right away-*
-The intruder neutralization...complete♪
+Intruder neutralization... Complete♪
 I hope the shop manager will praise me later,
 and maybe even give me a new item!
 
@@ -691,10 +696,10 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... already...❤
 
 アクティブ：上
 Ahh...❤
@@ -714,10 +719,10 @@ Hora, get down at my feet, and pathetically
 stroke yourself.*
 You're going to cum on your own just from our
 lewd aura while a succubus watches you.*
-Hitting you with a whip...jerking you off with
-my hand...all those things can wait.*
+Hitting you with a whip... Jerking you off with
+my hand... All those things can wait.*
 Because from what I can see, you're feeling
-really good already aren't you?*
+really good already, aren't you?*
 You can't defy the pleasure.
 Fall for me.*
 Humilate yourself and lose to a succubus,
@@ -738,10 +743,10 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... Already...❤
 
 アクティブ：上
 Ahh...❤
@@ -752,20 +757,20 @@ It would be terribly pathetic of you to neglect
 your duties as a soldier of the capital.
 Did you see how I dealt with the male before
 you?*
-Even when you wilingly submit, I don't need to
+Even when you willingly submit, I don't need to
 do anything but laugh- After all, it's what
-you requested isn't it? Teehee❤
+you requested, isn't it? Teehee❤
 Hora, get down at my feet, and pathetically
 stroke yourself.*
 You're going to cum on your own just from our
 lewd aura while a succubus watches you.*
-Hitting you with a whip...jerking you off with
-my hand...all those things can wait.*
+Hitting you with a whip... Jerking you off with
+my hand... All those things can wait.*
 Because from what I can see, you're feeling
-really good already aren't you?*
+really good already, aren't you?*
 You can't defy the pleasure.
 Fall for me.*
-You're only human after all.
+You're only human, after all.
 Humilate yourself and lose to a succubus,
 useless creature...❤ Teehee❤
 
@@ -776,51 +781,51 @@ to the enemy. What a fool...❤
 
 <TK3>
 Mizuhide：上
-Oough...I-I shouldn't but...❤
+Oough... I-I shouldn't but...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Oh...? So despite what you said earlier, you ended
 up masturbating in front of me.*
 Even if you're only a little taller than me,
 you're really just a child, right?❤
 I thought you were trying to take us down❤
 But instead you're on the floor going
-Stroke stroke♪ Stroke stroke♪
+stroke stroke♪ Stroke stroke♪
 It's so pathetic-❤
 Couldn't you resist the urges of your penis after
 having the aphrodisiac? What happened to your
 pride?
 Aha! Even though I'm looking down and making fun
 of you, your penis just keeps getting bigger♪*
-Hey- Masocist boy-
+Hey- Masochist boy-
 Shall I dribble this aphrodisiac lotion on your
 penis?
-If you want it, just ask OK?
+If you want it, just ask, okay?
 Hora...❤ And don't forget to look me in the eyes-
 
 Mizuhide：上
 Haahhhough❤
-P-Please... G-Give it to me...❤
+P-please... G-give it to me...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Kyhahaha! You're so obedient♪**
 You've completely given up against a girl way
-younger than you huh? Okay, I'll do it-*
+younger than you, huh? Okay, I'll do it-*
 Hora- My lotion is spilling onto your penis...❤**
 Aha! Your hips twitched the moment the lotion
 touched your penis. It'll make your penis feel
 all slippery and good-
-Sensitivity increasing...swelling up with
-pleasure... You can't stop stroking it at all now
+Sensitivity increasing... Swelling up with
+pleasure... You can't stop stroking it at all now,
 huh? Teehee❤
 I'll watch you so you can keep going until you cum.
-You can't hold back any more can you?*
+You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
@@ -831,37 +836,37 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... Already...❤
 
 アクティブ：上
 Ahh...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Oh...? What's wrong, Mr. Soldier?
 I thought you were trying to take us down...❤*
 But instead you're on the floor going
-Stroke stroke♪ Stroke stroke♪
+stroke stroke♪ Stroke stroke♪
 It's so pathetic-❤
 Couldn't you resist the urges of your penis after
 having the aphrodisiac?*
 Even a small child knows when to have self 
-control, but you can't even control yourself at
+control, but you can't control yourself at
 all- Teehee❤
 Hey- Hey- Shall I dribble this aphrodisiac lotion
-on your penis? Hora...dribble dribble❤
+on your penis? Hora... Dribble dribble❤*
 Aha! Your stroking got even faster♪
-Your penis feels all slippery and good right?*
+Your penis feels all slippery and good, right?*
 Hora- I'll watch you so you can keep going until
-you cum. You can't hold back any more can you?*
+you cum. You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
@@ -872,38 +877,38 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... already...❤
 
 アクティブ：上
 Ahh...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Teehee- Someone ended up masturbating in front
 of me again. I thought they were trying to stop
 criminals from selling bad succubus items...❤
 But instead they're on the floor going
-Stroke stroke♪ Stroke stroke♪
+stroke stroke♪ Stroke stroke♪
 It's so pathetic-❤
 Couldn't you resist the urges of your penis after
 having the aphrodisiac?*
 Even a small child knows when to have self 
-control, but you can't even control yourself at
+control, but you can't control yourself at
 all- Teehee❤
 Hey- Hey- Shall I dribble this aphrodisiac lotion
-on your penis? Hora...dribble dribble❤
+on your penis? Hora... Dribble dribble❤*
 Aha! Your stroking got even faster♪
-Your penis feels all slippery and good right?*
+Your penis feels all slippery and good, right?*
 Hora- I'll watch you so you can keep going until
-you cum. You can't hold back any more can you?*
+you cum. You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
@@ -911,9 +916,9 @@ Kyahaha♪
 
 <TK4>
 Mizuhide：上
-Oough...I-I shouldn't but...❤
+Oough... I-I shouldn't but...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Oh...? So despite what you said earlier, you ended
 up masturbating in front of me.*
 Even if you're only a little taller than me,
@@ -927,35 +932,35 @@ having the aphrodisiac? What happened to your
 pride?
 Aha! Even though I'm looking down and making fun
 of you, your penis just keeps getting bigger♪*
-Hey- Masocist boy-
+Hey- Masochist boy-
 Shall I dribble this aphrodisiac lotion on your
 penis?
-If you want it, just ask OK?
+If you want it, just ask, okay?
 Hora...❤ And don't forget to look me in the eyes-
 
 Mizuhide：上
 Haahhhough❤
-P-Please... G-Give it to me...❤
+P-please... G-give it to me...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Kyhahaha! You're so obedient♪**
 You've completely given up against a girl way
-younger than you huh? Okay, I'll do it-*
+younger than you, huh? Okay, I'll do it-*
 Hora- My lotion is spilling onto your penis...❤**
 Aha! Your hips twitched the moment the lotion
 touched your penis. It'll make your penis feel
 all slippery and good-
-Sensitivity increasing...swelling up with
-pleasure... You can't stop stroking it at all now
+Sensitivity increasing... Swelling up with
+pleasure... You can't stop stroking it at all now,
 huh? Teehee❤
 I'll watch you so you can keep going until you cum.
-You can't hold back any more can you?*
+You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
@@ -966,37 +971,37 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... Already...❤
 
 アクティブ：上
 Ahh...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Oh...? What's wrong, Mr. Soldier?
 I thought you were trying to take us down...❤*
 But instead you're on the floor going
-Stroke stroke♪ Stroke stroke♪
+stroke stroke♪ Stroke stroke♪
 It's so pathetic-❤
 Couldn't you resist the urges of your penis after
 having the aphrodisiac?*
 Even a small child knows when to have self 
-control, but you can't even control yourself at
+control, but you can't control yourself at
 all- Teehee❤
 Hey- Hey- Shall I dribble this aphrodisiac lotion
-on your penis? Hora...dribble dribble❤
+on your penis? Hora... Dribble dribble❤*
 Aha! Your stroking got even faster♪
-Your penis feels all slippery and good right?*
-Hora- 'll watch you so you can keep going until
-you cum. You can't hold back any more can you?*
+Your penis feels all slippery and good, right?*
+Hora- I'll watch you so you can keep going until
+you cum. You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
@@ -1007,38 +1012,38 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... Already...❤
 
 アクティブ：上
 Ahh...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Teehee- Someone ended up masturbating in front
 of me again. I thought they were trying to stop
 criminals from selling bad succubus items...❤
 But instead they're on the floor going
-Stroke stroke♪ Stroke stroke♪
+stroke stroke♪ Stroke stroke♪
 It's so pathetic-❤
 Couldn't you resist the urges of your penis after
 having the aphrodisiac?*
 Even a small child knows when to have self 
-control, but you can't even control yourself at
+control, but you can't control yourself at
 all- Teehee❤
 Hey- Hey- Shall I dribble this aphrodisiac lotion
-on your penis? Hora...dribble dribble❤
+on your penis? Hora... Dribble dribble❤*
 Aha! Your stroking got even faster♪
-Your penis feels all slippery and good right?*
-Hora- 'll watch you so you can keep going until
-you cum. You can't hold back any more can you?*
+Your penis feels all slippery and good, right?*
+Hora- I'll watch you so you can keep going until
+you cum. You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
@@ -1046,9 +1051,9 @@ Kyahaha♪
 
 <TK7>
 Mizuhide：上
-Oough...I-I shouldn't but...❤
+Oough... I-I shouldn't but...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Oh...? So despite what you said earlier, you ended
 up masturbating in front of me.*
 Even if you're only a little taller than me,
@@ -1062,35 +1067,35 @@ having the aphrodisiac? What happened to your
 pride?
 Aha! Even though I'm looking down and making fun
 of you, your penis just keeps getting bigger♪*
-Hey- Masocist boy-
+Hey- Masochist boy-
 Shall I dribble this aphrodisiac lotion on your
 penis?
-If you want it, just ask OK?
+If you want it, just ask, okay?
 Hora...❤ And don't forget to look me in the eyes-
 
 Mizuhide：上
 Haahhhough❤
-P-Please... G-Give it to me...❤
+P-please... G-give it to me...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Kyhahaha! You're so obedient♪**
 You've completely given up against a girl way
-younger than you huh? Okay, I'll do it-*
+younger than you, huh? Okay, I'll do it-*
 Hora- My lotion is spilling onto your penis...❤**
 Aha! Your hips twitched the moment the lotion
 touched your penis. It'll make your penis feel
 all slippery and good-
-Sensitivity increasing...swelling up with
-pleasure... You can't stop stroking it at all now
+Sensitivity increasing... Swelling up with
+pleasure... You can't stop stroking it at all now,
 huh? Teehee❤
 I'll watch you so you can keep going until you cum.
-You can't hold back any more can you?*
+You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
@@ -1101,79 +1106,79 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... Already...❤
 
 アクティブ：上
 Ahh...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Oh...? What's wrong, Mr. Soldier?
 I thought you were trying to take us down...❤*
 But instead you're on the floor going
-Stroke stroke♪ Stroke stroke♪
+stroke stroke♪ Stroke stroke♪
 It's so pathetic-❤
 Couldn't you resist the urges of your penis after
 having the aphrodisiac?*
 Even a small child knows when to have self 
-control, but you can't even control yourself at
+control, but you can't control yourself at
 all- Teehee❤
 Hey- Hey- Shall I dribble this aphrodisiac lotion
-on your penis? Hora...dribble dribble❤
+on your penis? Hora... Dribble dribble❤*
 Aha! Your stroking got even faster♪
-Your penis feels all slippery and good right?*
-Hora- 'll watch you so you can keep going until
-you cum. You can't hold back any more can you?*
+Your penis feels all slippery and good, right?*
+Hora- I'll watch you so you can keep going until
+you cum. You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
 Kyahaha♪
 
-<TK9>
+<TK6>
 Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... Already...❤
 
 アクティブ：上
 Ahh...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Teehee- Someone ended up masturbating in front
 of me again. I thought they were trying to stop
 criminals from selling bad succubus items...❤
 But instead they're on the floor going
-Stroke stroke♪ Stroke stroke♪
+stroke stroke♪ Stroke stroke♪
 It's so pathetic-❤
 Couldn't you resist the urges of your penis after
 having the aphrodisiac?*
 Even a small child knows when to have self 
-control, but you can't even control yourself at
+control, but you can't control yourself at
 all- Teehee❤
 Hey- Hey- Shall I dribble this aphrodisiac lotion
-on your penis? Hora...dribble dribble❤
+on your penis? Hora... Dribble dribble❤*
 Aha! Your stroking got even faster♪
-Your penis feels all slippery and good right?*
-Hora- 'll watch you so you can keep going until
-you cum. You can't hold back any more can you?*
+Your penis feels all slippery and good, right?*
+Hora- I'll watch you so you can keep going until
+you cum. You can't hold back any more, can you?*
 Stroke stroke❤ Stroke stroke❤
-Stroke stroke❤ Stroke stroke❤
+Stroke stroke❤ Stroke stroke❤*
 Ah, your hips twitched again...❤ You're going to
 cum... Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- What a huge amount of creamy semen.
 I'll be able to heal right up with this.*
 Thanks for the energy, "big" brother-
@@ -1184,10 +1189,10 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... Already...❤
 
 アクティブ：上
 Ahh...❤
@@ -1199,7 +1204,7 @@ Maybe you ended up getting caught in the sweet
 smell of my aroma?
 Your mindless expression is so cute-
 What are you jerking off to?
-My boobs? Butt? Or maybe...my thighs?*
+My boobs? Butt? Or maybe... My thighs?*
 Ufufu, your eyes can't decide what to look at-
 Stroke stroke, stroke stroke...❤*
 What a bad, bad soldier, lavishing in my body
@@ -1208,12 +1213,12 @@ Hm? Are you going to cum already?
 I see. Well then, go ahead and bury yourself in
 my body once you're ready.
 Breathe in my sweet scent as much as you can
-while shooting it all out, OK?
+while shooting it all out, okay?
 Hora...❤
 
 Perfume Succubus：上
 Ufufu- What a happy expression.
-You came a whole lot didn't you?*
+You came a whole lot, didn't you?*
 I wonder if it felt good, forgetting all about
 your companions, ejaculating as your mind went
 pink❤
@@ -1223,10 +1228,10 @@ Ray：上
 Haah... Haah...❤
 
 Miles：上
-Oough...❤ D-Dammit...❤
+Oough...❤ D-dammit...❤
 
 Nobus：上
-Not good... I'm...already...❤
+Not good... I'm... Already...❤
 
 アクティブ：上
 Ahh...❤
@@ -1241,7 +1246,7 @@ Maybe you ended up getting caught in the sweet
 smell of my aroma?
 Your mindless expression is so cute-
 What are you jerking off to?
-My boobs? Butt? Or maybe...my thighs?*
+My boobs? Butt? Or maybe... My thighs?*
 Ufufu, your eyes can't decide what to look at-
 Stroke stroke, stroke stroke...❤*
 What a bad, bad soldier, lavishing in my body
@@ -1250,12 +1255,12 @@ Hm? Are you going to cum already?
 I see. Well then, go ahead and bury yourself in
 my body once you're ready.
 Breathe in my sweet scent as much as you can
-while shooting it all out, OK?
+while shooting it all out, okay?
 Hora...❤
 
 Perfume Succubus：上
 Ufufu- What a happy expression.
-You came a whole lot didn't you?*
+You came a whole lot, didn't you?*
 I wonder if it felt good, forgetting all about
 your companions, ejaculating as your mind went
 pink❤
@@ -1269,18 +1274,19 @@ Oough...❤ Please...❤
 I can't take it anymore...❤
 
 Nobus：上
-Not good.. I'm...already...❤ Just a glance and...❤
+Not good.. I'm... Already...❤ 
+Just a glance and...❤
 Ooough, I'm begging you...❤
 
 アクティブ：上
-Oough...please make me feel good❤
+Oough... Please make me feel good❤
 Please...❤
 
 Black Marketeer：上
 Ara ara, do you realize what you're saying?
-To say "please let me feel good" after just 
+To say "Please let me feel good" after just 
 managing to reach the enemy leader...❤
-Pfft- Humans really are fools huh?❤
+Pfft- Humans really are fools, huh?❤
 
 選択肢：1
 Handjob Strike Lv3
@@ -1292,16 +1298,16 @@ Very well- I'll show you heaven with my
 techniques❤
 
 Black Marketeer：上
-So you want to ejaculated being hit with this
+So you want to ejaculate from being hit with this
 whip? Ahaha! Perverts are full of surprises❤*
-Very well. I'll facinate you plenty with my
+Very well. I'll fascinate you plenty with my
 magic infused whip❤
 
 Black Marketeer：上
 Kuhu- You went and shamefully ejaculated with a
 great big moan❤*
 Does anyone else have a request?
-I'll make you feel so good you'll cum OK?
+I'll make you feel so good you'll cum, okay?
 Teehee...❤
 
 <TK14>
@@ -1313,22 +1319,23 @@ Oough...❤ Please...❤
 I can't take it anymore...❤
 
 Nobus：上
-Not good.. I'm...already...❤ Just a glance and...❤
+Not good.. I'm... Already...❤ 
+Just a glance and...❤
 Ooough, I'm begging you...❤
 
 アクティブ：上
-Oough...please make me feel good❤
+Oough... Please make me feel good❤
 Please...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Huh?❤ You want me to stroke your penis with this
-onahole? I cann't believe a male is asking me to
+onahole? I can't believe a male is asking me to
 do this❤
 I take it you've gone and given up on trying
 to arrest us then?❤ What a weak penis you have,
 it can't resist at all❤ Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- You let out so much❤
 It's so warm inside too❤*
 Congrats on being able to make my fake pussy
@@ -1343,22 +1350,23 @@ Oough...❤ Please...❤
 I can't take it anymore...❤
 
 Nobus：上
-Not good.. I'm...already...❤ Just a glance and...❤
+Not good.. I'm... Already...❤ 
+Just a glance and...❤
 Ooough, I'm begging you...❤
 
 アクティブ：上
-Oough...please make me feel good❤
+Oough... Please make me feel good❤
 Please...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Huh?❤ You want me to stroke your penis with this
-onahole? I cann't believe a male is asking me to
+onahole? I can't believe a male is asking me to
 do this❤
 I take it you've gone and given up on trying
 to arrest us then?❤ What a weak penis you have,
 it can't resist at all❤ Teehee❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ahh- You let out so much❤
 It's so warm inside too❤*
 Congrats on being able to make my fake pussy
@@ -1373,22 +1381,23 @@ Oough...❤ Please...❤
 I can't take it anymore...❤
 
 Nobus：上
-Not good.. I'm...already...❤ Just a glance and...❤
+Not good.. I'm... Already...❤ 
+Just a glance and...❤
 Ooough, I'm begging you...❤
 
 アクティブ：上
-Oough...please make me feel good❤
+Oough... Please make me feel good❤
 Please...❤
 
- Lotion Succubus：上
+Lotion Succubus：上
 Ehehe❤ So you want me to go rub rub rub- with my
 boobs? Even with small boobs like these,
 you still want a paizuri from them?❤
 
- Lotion Succubus：上
-Ahh- Your letting out so much-❤
+Lotion Succubus：上
+Ahh- You're letting out so much-❤
 There's so much on my body...
-That felt really good didn't it?
+That felt really good, didn't it?
 
 <TK17>
 Ray：上
@@ -1399,11 +1408,12 @@ Oough...❤ Please...❤
 I can't take it anymore...❤
 
 Nobus：上
-Not good.. I'm...already...❤ Just a glance and...❤
+Not good.. I'm... Already...❤ 
+Just a glance and...❤
 Ooough, I'm begging you...❤
 
 アクティブ：上
-Oough...please make me feel good❤
+Oough... Please make me feel good❤
 Please...❤
 
 Perfume Succubus：上
@@ -1411,7 +1421,7 @@ Ara, you only just broke through the back door,
 and the smell of perfume has already melted your
 mind?
 Pleading "Make me feel good❤" while clinging to
-me...Ufufu♪ How unsightly❤
+me... Ufufu♪ How unsightly❤
 
 Perfume Succubus：上
 Mm- You shot a lot out between my thighs❤
@@ -1433,31 +1443,31 @@ you❤
 
 Ray：上
 Go ahead and submit to these boobs this time
-as well okay?
+as well, okay?
 
 Ray：上
-Oppsies...❤
+Oopsies...❤
 
 Ray：上
 Ahaha!
 The people who ended up feeling good and submitted
 to me the other day got charmed from just a flash
 of my boobs❤
-Looks like this will be an easy victory huh?
+Looks like this will be an easy victory, huh?
 Teehee♪
 
 <OP0>
 Mizuhide：上
 Good morning Ray.
-Do you have a small moment to spare?*
+Do you have a moment to spare?*
 Have a look at this.
 This is supposed to be a dataset of crimes
-commited within the kingdom...
-But since the appearance of succubus, the crimes
+committed within the kingdom...
+But since the appearance of succubi, the crimes
 committed by females have increased dramatically.*
 And take note of this point here. All of those
-commited crimes involved magical items.*
-Lots of never heard before items are being used.
+committed crimes involved magical items.*
+Many items we've never heard of are being used.
 Highly addictive aphrodisiacs, brainwashing
 collars, and pleasure crests, to name a few.
 Looking at this data in chronological order, I
@@ -1478,7 +1488,7 @@ southern village had that suspicious aphrodisiac
 as well.
 It must have spread a considerable distance to
 be circulating that far away from the royal
-captital.
+capital.
 
 Mizuhide：上
 Even in an area considerably further away from the
@@ -1491,14 +1501,14 @@ Mizuhide：上
 It would be a dangerous matter to ignore the
 impact they're having on the community.*
 We should take measures before the magical
-succubus items spread any further to other
+succubus items spread further to other
 crime groups.
 So I have a request. May I ask for your help
-in finding the Black Marketeer's hide out
+in finding the Black Marketeer's hideout
 together?
 
 選択肢：1
-Of course
+Of course.
 
 Mizuhide：上
 I can't thank you enough.
@@ -1508,9 +1518,9 @@ all the strength we need.
 Miles：上
 Although you say that, but you'll probably be 
 busy with making a plan to attack the succubus
-hide out right Mizuhide?
+hideout right, Mizuhide?
 Fear not. We'll take the lead, and work out
-where the Black Market hideout is.
+where the Black Market hideout is.*
 Then you'll only need to join up when we
 break in.
 
@@ -1532,14 +1542,14 @@ a shadow or two.*
 Besides, Nobus's house was also a weapons shop,
 so I used our connections to trace back where
 the goods were being distributed.
-And...there. The Black Market is just out of
-town in a pharmacy basement two days from here.
-Head there now, and we'll surpress their
+And... There. The Black Market is just out of
+town in a pharmacy basement two days from here.*
+Head there now, and we'll suppress their
 activities in one fell swoop.
 
 Mizuhide：上
 Understood.
-My preparations are all ready.
+My preparations are complete.
 
 選択肢：1
 Right. Let's go!
@@ -1552,7 +1562,7 @@ I doubt anyone would notice this.
 Miles：上
 This shop doesn't just have a front entrance, it
 also has a back door.*
-I'll invade from the back entrance. Ray and
+I'll head in from the back. Ray and
 Mizuhide, you two go in from the front.*
 We'll pincer them from both sides, and take them
 out in one smooth motion. I'll take my place,
@@ -1570,34 +1580,34 @@ What's going on....?*
 Ara, soldiers from the royal capital?
 What brings you here at this time?*
 Kicking in the door of a mere pharmacy shop,
-and all angry faces too!
+and all of you with angry faces too!
 
 Mizuhide：上
 It's no use pretending! We know this shop has
-selling magical items that taint the human
+been selling magical items that taint the human
 mind!
 We'll hear your excuses after you've been 
-restrained. Now come quitely and let us
+restrained. Now come quietly and let us
 tie you up!
 
- Lotion Succubus：上
+Lotion Succubus：上
 Oh? Illegal items?
 You mean, like this lotion?
 
 ：スチル
-A girl appeared from shadows cast by the shelves
-of goods, and drizzled some pink liquid out of a
-bottle.
+A girl appeared from the shadows cast by the 
+shelves of goods, and drizzled some pink liquid 
+out of a bottle.
 Smearing it over her hands, she began moving her
 fingers as if gripping something, making sure we
 all saw what she was doing.
 
- Lotion Succubus：上
+Lotion Succubus：上
 Teehee❤ It's so lewd when they stare-
 Being touched by this slippery hand would feel
-so good wouldn't it?
+so good, wouldn't it?
 But it's not a particularly dangerous magical
-item right? We're just playful girls with playful
+item, right? We're just playful girls with playful
 hands. That's why everyone loves what we do-
 Hora, why don't you find out for yourselves?
 You're only a little taller than me, but I bet
@@ -1615,7 +1625,7 @@ upset. How cute-
 
 Black Marketeer：上
 We really ought to punish you boys for unlawful
-tresspassing huh? Let's drown your cheeky selves
+tresspassing, huh? Let's drown your cheeky selves
 in pleasure...
-Whether we're bad or good...we'll make you feel
+Whether we're bad or good... We'll make you feel
 good either way... Ufufufu❤

--- a/English translation/rest.txt
+++ b/English translation/rest.txt
@@ -3693,7 +3693,7 @@ too aroused by Mirage's teasing.
 <ED4>
 Mirage：上
 Oh, hey there Ray!
-It's a real shame about Nobus huh?*
+It's a real shame about Nobus, huh?*
 Suddenly betrayed by your closest friend, barely
 making it out of that surprise attack alive...
 After that, you must be soo tired-

--- a/English translation/rest.txt
+++ b/English translation/rest.txt
@@ -13264,7 +13264,7 @@ Ray：上
 Oooh...❤ Aaah, that feels soo good-❤
 
 Mirage：上
-Right?- It feels good doesn't it?-
+Right?- It feels good, doesn't it?-
 I'll make you cum soon-❤ So don't fight it-❤*
 Hora- Stroke stroke stroke♪
 While my small hands grasp around your penis,
@@ -13412,7 +13412,7 @@ I see, so you want me to use my hands after all-
 Good choice-❤*
 Hora- Let's go over to that tree over there, okay?
 
-Ray：上
+Mirage：上
 (Giggle) The Elves all walk past this spot, right?
 No one would ever think that the hero would be
 doing such a thing near here-
@@ -13436,10 +13436,10 @@ Hora-
 First I'll grasp the length with my hands and...
 Stroke stroke stroke♪ Stroke stroke stroke♪
 
-Mirage：上
+Ray：上
 Aah... aaah...❤
 
-Ray：上
+Mirage：上
 Kyahaha- I'm only just moving a little, and
 you're already moaning♪
 Does it feel that good?
@@ -13449,34 +13449,34 @@ Next I'll tightly hold your shaft and squee-eeze-
 If I do this, it'll feel just like you're
 being milked...
 
-Mirage：上
+Ray：上
 Oooh...❤ Aaah, that feels soo good-❤
 
-Elf：上
+Mirage：上
 Right?- It feels good doesn't it?-
 I'll make you cum soon-❤ So don't fight it-❤*
 Hora- Stroke stroke stroke♪
 While my small hands grasp around your penis,
 Stroke stroke stroke-♪　Stroke stroke stroke♪
 
-Ray：上
+Elf：上
 Huh-? Mr. Leader, 
 what are you doing in a place like this?
 
-Mirage：上
+Ray：上
 ...!!!
 
-Ray：上
+Mirage：上
 Uh oh♪
 You got discovered by an Elf girl-*
 But, I'm not going to stop stroking-❤
 You'd better endure if you don't want to be
 found out♪
 
-Elf：上
+Ray：上
 Wai-❤　Aaah-❤, aaah-❤
 
-Mirage：上
+Elf：上
 Hey- Is something wrong?
 You're slouching so much, and your face is
 all red too.
@@ -13484,7 +13484,7 @@ And what's with all the weird noises?
 Perhaps you're still sick from the Holy Sword?
 Are you okay?
 
-Ray：上
+Mirage：上
 Pfft- She's so worried about you, but the truth is
 you're just getting jerked off by a young girl♪
 What a pervert-❤
@@ -13505,10 +13505,10 @@ is looking at you-❤ Kyahaha♪
 Ray：上
 Aaah, oh no-❤ It's too much-❤ I'm already...!❤
 
-Elf：上
+Ray：上
 Aah, aaaah...!
 
-Mirage：上
+Elf：上
 Huh? Huh?
 Hey, are you alright!?*
 You suddenly collapsed...
@@ -13527,7 +13527,7 @@ Mr. Ray is a masochist after all, so thinking
 about things you shouldn't be doing just makes the 
 pleasure more intense doesn't it, Mr. Per-vert?❤
 
-Elf：上
+Mirage：上
 And now to taste this semen... 
 Mmm!-♪ I can feel your delicious power
 melting in my mouth-❤
@@ -13536,13 +13536,7 @@ with me-*
 I'll make you feel really good in return too-
 I'm be looking forward to next time- Kyahaha♪
 
-テロップ：中央
-エルフの女の子は気まずそうに去っていった。
-
-テロップ：中央
-My strength was squeezed by Mirage...
-
-Mirage：上
+Elf：上
 Umm, so... 
 I guess that explains why you
 were doing... "That", huh...?


### PR DESCRIPTION
qa14 is completely Japanese, looks like it has the generic healing circle lines and something about waves. Survival mode? Added the generic healing lines in case it comes up later.

Line 732-733. Japanese implies that these are soldiers, not just prisoners.

Line 749-750. Same as lines 784 and 785 in Japanese, copied that translation over this one since it sounded better.

qa10 is still in Japanese.

For QA9

OP1 name tags are wrong, even in the original Japanese.
Lines 1439, 1444, 1448, and 1451 in the English file.
Lines 1380, 1384, 1387, and 1390 in the Japanese file.

Lines 1618-1619 sound a bit off, MTL of the Japanese line doesn't make the meaning clear enough to rewrite it.
The Japanese line is 1545.
Please take a look when you can.

Rest of the changes are misspellings, commas, OK to okay, and minor rephrasing.

Fixed nametags in rest.txt

QA11 missing from the English files. Not used?